### PR TITLE
restructure online events

### DIFF
--- a/src/__mocks__/astro-actions.ts
+++ b/src/__mocks__/astro-actions.ts
@@ -1,3 +1,5 @@
 export const actions = {
   createEvent: () => Promise.resolve({ data: { success: true } }),
+  getLocations: () => Promise.resolve({ data: [{ id: 1, name: "Trieste" }, { id: 2, name: "Online" }] }),
+  getVenues: () => Promise.resolve({ data: [] }),
 };

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -2,7 +2,6 @@ import { defineAction, ActionError } from 'astro:actions';
 import { supabase, supabaseAdmin } from '../lib/supabase';
 import { sendMailchimpEmail } from '../lib/mailchimp';
 import { verifySessionToken } from '../lib/auth';
-import { CITY } from '../types/types';
 
 const createEvent = defineAction({
   accept: 'form',
@@ -20,7 +19,10 @@ const createEvent = defineAction({
     const name = formData.get('name') as string;
     const date = formData.get('date') as string;
     const slug = formData.get('slug') as string;
-    const city = (formData.get('city') as string) || CITY.TRIESTE;
+    const location_id = formData.get('location_id')
+      ? Number(formData.get('location_id'))
+      : null;
+    const meeting_url = (formData.get('meeting_url') as string) || null;
     const location_name = (formData.get('location_name') as string) || null;
     const location_url = (formData.get('location_url') as string) || null;
 
@@ -33,10 +35,10 @@ const createEvent = defineAction({
     }
 
     let venue_id: number | null = null;
-    if (location_name) {
+    if (location_id && location_name) {
       const { data: venue, error: venueError } = await supabaseAdmin
         .from('venues')
-        .upsert({ name: location_name, url: location_url, city }, { onConflict: 'name,city' })
+        .upsert({ name: location_name, url: location_url, location_id }, { onConflict: 'name,location_id' })
         .select('id')
         .single();
 
@@ -50,7 +52,9 @@ const createEvent = defineAction({
         name,
         date,
         slug,
+        location_id,
         venue_id,
+        meeting_url,
         instagram: (formData.get('instagram') as string) || null,
         facebook: (formData.get('facebook') as string) || null,
         meetup: (formData.get('meetup') as string) || null,
@@ -75,6 +79,7 @@ const createEvent = defineAction({
       name,
       date,
       slug,
+      meeting_url,
       venue_name: location_name,
       venue_url: location_url,
     }).catch((e) => console.error('Mailchimp draft creation failed:', e));
@@ -99,7 +104,10 @@ const updateEvent = defineAction({
     const slug = formData.get('slug') as string;
     const name = formData.get('name') as string;
     const date = formData.get('date') as string;
-    const city = (formData.get('city') as string) || CITY.TRIESTE;
+    const location_id = formData.get('location_id')
+      ? Number(formData.get('location_id'))
+      : null;
+    const meeting_url = (formData.get('meeting_url') as string) || null;
     const location_name = (formData.get('location_name') as string) || null;
     const location_url = (formData.get('location_url') as string) || null;
 
@@ -108,10 +116,10 @@ const updateEvent = defineAction({
     }
 
     let venue_id: number | null = null;
-    if (location_name) {
+    if (location_id && location_name) {
       const { data: venue, error: venueError } = await supabaseAdmin
         .from('venues')
-        .upsert({ name: location_name, url: location_url, city }, { onConflict: 'name,city' })
+        .upsert({ name: location_name, url: location_url, location_id }, { onConflict: 'name,location_id' })
         .select('id')
         .single();
 
@@ -124,7 +132,9 @@ const updateEvent = defineAction({
       .update({
         name,
         date,
+        location_id,
         venue_id,
+        meeting_url,
         instagram: (formData.get('instagram') as string) || null,
         facebook: (formData.get('facebook') as string) || null,
         meetup: (formData.get('meetup') as string) || null,
@@ -148,6 +158,22 @@ const updateEvent = defineAction({
   }
 });
 
+const getLocations = defineAction({
+  handler: async () => {
+    if (!supabase) {
+      throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Supabase not configured' });
+    }
+
+    const { data, error } = await supabase
+      .from('locations')
+      .select('id, name')
+      .order('name');
+
+    if (error) throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
+    return data ?? [];
+  }
+});
+
 const getVenues = defineAction({
   handler: async (_, context) => {
     const token = context.cookies.get('session')?.value;
@@ -162,7 +188,7 @@ const getVenues = defineAction({
 
     const { data, error } = await supabase
       .from('venues')
-      .select('id, name, url, city')
+      .select('id, name, url, location_id')
       .order('name');
 
     if (error) throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
@@ -173,5 +199,6 @@ const getVenues = defineAction({
 export const server = {
   createEvent,
   updateEvent,
+  getLocations,
   getVenues,
 };

--- a/src/components/EventForm/EventForm.test.tsx
+++ b/src/components/EventForm/EventForm.test.tsx
@@ -5,12 +5,14 @@ import EventForm from "./EventForm";
 
 const mockCreateEvent = vi.fn();
 const mockUpdateEvent = vi.fn();
+const mockGetLocations = vi.fn();
 const mockGetVenues = vi.fn();
 
 vi.mock("astro:actions", () => ({
   actions: {
     createEvent: (...args: unknown[]) => mockCreateEvent(...args),
     updateEvent: (...args: unknown[]) => mockUpdateEvent(...args),
+    getLocations: (...args: unknown[]) => mockGetLocations(...args),
     getVenues: (...args: unknown[]) => mockGetVenues(...args),
   },
 }));
@@ -18,11 +20,10 @@ vi.mock("astro:actions", () => ({
 const sampleInitialData = {
   name: "Test Event",
   date: "2025-06-01T19:00",
-  city: "Trieste",
+  locationId: 1,
   slug: "test-event",
 };
 
-/** Waits for the async venue fetch to complete so the real select is rendered. */
 async function waitForVenuesToLoad() {
   await waitFor(() => {
     expect(screen.queryByText("Loading venues…")).not.toBeInTheDocument();
@@ -32,6 +33,7 @@ async function waitForVenuesToLoad() {
 describe("EventForm (create mode)", () => {
   beforeEach(() => {
     mockCreateEvent.mockReset();
+    mockGetLocations.mockResolvedValue({ data: [{ id: 1, name: "Trieste" }, { id: 2, name: "Online" }] });
     mockGetVenues.mockResolvedValue({ data: [] });
   });
 
@@ -44,7 +46,7 @@ describe("EventForm (create mode)", () => {
   });
 
   it("disables submit button while submitting", async () => {
-    mockCreateEvent.mockReturnValue(new Promise(() => {})); // never resolves
+    mockCreateEvent.mockReturnValue(new Promise(() => {}));
     render(<EventForm mode="create" />);
 
     await waitForVenuesToLoad();
@@ -83,6 +85,7 @@ describe("EventForm (create mode)", () => {
 describe("EventForm (edit mode)", () => {
   beforeEach(() => {
     mockUpdateEvent.mockReset();
+    mockGetLocations.mockResolvedValue({ data: [{ id: 1, name: "Trieste" }, { id: 2, name: "Online" }] });
     mockGetVenues.mockResolvedValue({ data: [] });
   });
 
@@ -106,7 +109,7 @@ describe("EventForm (edit mode)", () => {
   });
 
   it("disables submit button and shows loading placeholder while venues are loading", () => {
-    mockGetVenues.mockReturnValue(new Promise(() => {})); // never resolves
+    mockGetVenues.mockReturnValue(new Promise(() => {}));
     render(<EventForm mode="edit" initialData={sampleInitialData} />);
 
     expect(screen.getByText("Loading venues…")).toBeInTheDocument();
@@ -151,8 +154,8 @@ describe("EventForm (edit mode)", () => {
 
   it("pre-selects the venue matching initialData.venueId", async () => {
     const venues = [
-      { id: 5, name: "The Philosophy Bar", url: null, city: "Trieste" },
-      { id: 6, name: "Another Venue", url: null, city: "Trieste" },
+      { id: 5, name: "The Philosophy Bar", url: null, location_id: 1 },
+      { id: 6, name: "Another Venue", url: null, location_id: 1 },
     ];
     mockGetVenues.mockResolvedValue({ data: venues });
     render(<EventForm mode="edit" initialData={{ ...sampleInitialData, venueId: 5 }} />);
@@ -163,7 +166,7 @@ describe("EventForm (edit mode)", () => {
   });
 
   it("does not pre-select a venue when no venueId is provided", async () => {
-    const venues = [{ id: 5, name: "The Philosophy Bar", url: null, city: "Trieste" }];
+    const venues = [{ id: 5, name: "The Philosophy Bar", url: null, location_id: 1 }];
     mockGetVenues.mockResolvedValue({ data: venues });
     render(<EventForm mode="edit" initialData={sampleInitialData} />);
 

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -1,20 +1,21 @@
 import { useState, useEffect } from "react";
 import { actions } from "astro:actions";
-import { CITY } from "../../types/types";
-import type { City } from "../../types/types";
 
-type Venue = { id: number; name: string; url: string | null; city: string };
+type Location = { id: number; name: string };
+type Venue = { id: number; name: string; url: string | null; location_id: number };
 
 const NEW_VENUE = "__new__";
+const DEFAULT_MEETING_URL = import.meta.env.PUBLIC_DEFAULT_MEETING_URL || '';
 
 export type EventFormInitialData = {
   name: string;
-  date: string; // datetime-local format e.g. "2025-06-01T19:00"
-  city: string;
+  date: string;
+  locationId?: number;
   slug: string;
   venueId?: number;
   locationName?: string;
   locationUrl?: string;
+  meetingUrl?: string;
   instagram?: string;
   facebook?: string;
   meetup?: string;
@@ -28,12 +29,11 @@ type EventFormProps = {
 };
 
 export default function EventForm({ mode, initialData }: EventFormProps) {
-  const [status, setStatus] = useState<
-    "idle" | "loading" | "success" | "error"
-  >("idle");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [errorMessage, setErrorMessage] = useState("");
-  const [city, setCity] = useState<City>(
-    (initialData?.city as City) ?? CITY.TRIESTE
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [selectedLocationId, setSelectedLocationId] = useState<number | "">(
+    initialData?.locationId ?? ""
   );
   const [venues, setVenues] = useState<Venue[]>([]);
   const [venuesLoading, setVenuesLoading] = useState(true);
@@ -42,13 +42,17 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
   );
 
   useEffect(() => {
+    actions.getLocations().then(({ data }) => {
+      if (data) setLocations(data);
+    });
     actions.getVenues().then(({ data }) => {
       if (data) setVenues(data);
       setVenuesLoading(false);
     });
   }, []);
 
-  const cityVenues = venues.filter((v) => v.city === city);
+  const isOnline = locations.find((l) => l.id === selectedLocationId)?.name === "Online";
+  const locationVenues = venues.filter((v) => v.location_id === selectedLocationId);
   const isNewVenue = selectedVenueId === NEW_VENUE;
   const selectedVenue = venues.find((v) => String(v.id) === selectedVenueId);
 
@@ -65,8 +69,7 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
     }
 
     try {
-      const action =
-        mode === "edit" ? actions.updateEvent : actions.createEvent;
+      const action = mode === "edit" ? actions.updateEvent : actions.createEvent;
       const { error, data } = await action(formData);
 
       if (error) {
@@ -78,7 +81,7 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
       if (data?.success) {
         setStatus("success");
         if (mode === "create") {
-          setCity(CITY.TRIESTE);
+          setSelectedLocationId("");
           setSelectedVenueId("");
           const form = e.currentTarget as HTMLFormElement;
           if (form) form.reset();
@@ -109,7 +112,6 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="cnf-form">
-      {/* Hidden slug input for edit mode — carries the identifier for the action */}
       {mode === "edit" && (
         <input type="hidden" name="slug" value={initialData?.slug ?? ""} />
       )}
@@ -143,52 +145,68 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
       </div>
 
       <div className="cnf-form__group">
-        <label className="cnf-form__label" htmlFor="city">
-          City
+        <label className="cnf-form__label" htmlFor="location">
+          Location
         </label>
         <select
           className="cnf-form__input"
-          id="city"
-          name="city"
-          value={city}
+          id="location"
+          name="location_id"
+          value={selectedLocationId}
           onChange={(e) => {
-            setCity(e.target.value as City);
+            setSelectedLocationId(e.target.value ? Number(e.target.value) : "");
             setSelectedVenueId("");
           }}
         >
-          {Object.values(CITY).map((c) => (
-            <option key={c} value={c}>
-              {c}
+          <option value="">— select —</option>
+          {locations.map((l) => (
+            <option key={l.id} value={l.id}>
+              {l.name}
             </option>
           ))}
         </select>
       </div>
 
-      <div className="cnf-form__group">
-        <label className="cnf-form__label" htmlFor="venue_select">
-          Venue
-        </label>
-        {venuesLoading ? (
-          <select className="cnf-form__input" id="venue_select" disabled>
-            <option>Loading venues…</option>
-          </select>
-        ) : (
-          <select
+      {isOnline ? (
+        <div className="cnf-form__group">
+          <label className="cnf-form__label" htmlFor="meeting_url">
+            Meeting URL
+          </label>
+          <input
             className="cnf-form__input"
-            id="venue_select"
-            value={selectedVenueId}
-            onChange={(e) => setSelectedVenueId(e.target.value)}
-          >
-            <option value="">— none —</option>
-            {cityVenues.map((v) => (
-              <option key={v.id} value={String(v.id)}>
-                {v.name}
-              </option>
-            ))}
-            <option value={NEW_VENUE}>New venue...</option>
-          </select>
-        )}
-      </div>
+            type="url"
+            id="meeting_url"
+            name="meeting_url"
+            defaultValue={initialData?.meetingUrl ?? DEFAULT_MEETING_URL}
+          />
+        </div>
+      ) : selectedLocationId ? (
+        <div className="cnf-form__group">
+          <label className="cnf-form__label" htmlFor="venue_select">
+            Venue
+          </label>
+          {venuesLoading ? (
+            <select className="cnf-form__input" id="venue_select" disabled>
+              <option>Loading venues…</option>
+            </select>
+          ) : (
+            <select
+              className="cnf-form__input"
+              id="venue_select"
+              value={selectedVenueId}
+              onChange={(e) => setSelectedVenueId(e.target.value)}
+            >
+              <option value="">— none —</option>
+              {locationVenues.map((v) => (
+                <option key={v.id} value={String(v.id)}>
+                  {v.name}
+                </option>
+              ))}
+              <option value={NEW_VENUE}>New venue...</option>
+            </select>
+          )}
+        </div>
+      ) : null}
 
       {isNewVenue && (
         <>

--- a/src/components/EventList/EventList.test.tsx
+++ b/src/components/EventList/EventList.test.tsx
@@ -13,7 +13,10 @@ vi.mock("../Selector/Selector", () => ({
 }));
 
 vi.mock("../UpcomingEvent", () => ({
-  default: ({ event }: { event: { name: string } }) => <div data-testid="upcoming-event">{event.name}</div>,
+  default: ({ events }: { events: { name: string }[] }) => {
+    const current = events.find(() => true);
+    return <div data-testid="upcoming-event">{current?.name}</div>;
+  },
 }));
 
 vi.mock("../../layouts/EventCard", () => ({
@@ -22,16 +25,17 @@ vi.mock("../../layouts/EventCard", () => ({
 
 vi.mock("../../styles/event.css", () => ({}));
 
-function makeEvent(name: string, date: Date, city = "Trieste"): EventCollection {
+function makeEvent(name: string, date: Date, locationName = "Trieste"): EventCollection {
   return {
     id: name,
     data: {
       name,
       date,
-      city,
+      location: { id: 1, name: locationName },
+      venue: { name: "Test Venue", url: "https://maps.google.com" },
       slug: name.toLowerCase().replace(/ /g, "-"),
-      location: { name: "Test Venue", url: "https://maps.google.com" },
       social: { instagram: "https://instagram.com/test" },
+      meetingUrl: null,
     },
   } as unknown as EventCollection;
 }
@@ -83,7 +87,7 @@ describe("EventList", () => {
       expect(cards[2]).toHaveTextContent("Oldest");
     });
 
-    it("shows empty state when no past events in selected city", () => {
+    it("shows empty state when no past events in selected location", () => {
       const events = [makeEvent("Future Event", futureDate1, "Trieste")];
       render(<EventList events={events} />);
       fireEvent.click(screen.getByText("Past"));
@@ -91,8 +95,8 @@ describe("EventList", () => {
     });
   });
 
-  describe("city filtering", () => {
-    it("filters events by selected city", () => {
+  describe("location filtering", () => {
+    it("filters events by selected location", () => {
       const events = [
         makeEvent("Trieste Event", futureDate1, "Trieste"),
         makeEvent("Dublin Event", futureDate2, "Dublin"),

--- a/src/components/EventList/EventList.tsx
+++ b/src/components/EventList/EventList.tsx
@@ -5,30 +5,32 @@ import EventCard from "../../layouts/EventCard";
 import { formatBlogDate } from "../../utils/script";
 import Selector from "../Selector/Selector";
 import type { EventCollection } from "../../types/types";
-import { CITY } from "../../types/types";
 
 export default function EventList(props: EventListProps) {
-  const cities = [...new Set(props.events.map((e) => e.data.city).filter(Boolean))] as string[];
-
+  const locationNames = [...new Set(
+    props.events.map((e) => e.data.location?.name).filter(Boolean) as string[]
+  )];
   const [showUpcoming, setShowUpcoming] = useState<boolean>(true);
-  const [selectedCity, setSelectedCity] = useState<string>(cities[0] ?? CITY.TRIESTE);
+  const [selectedLocation, setSelectedLocation] = useState<string>(locationNames[0] ?? "");
 
-  const filteredEvents = props.events.filter(
-    (event) => event.data.city === selectedCity
-  );
-  const upcomingEvents = filteredEvents.filter(
+  const onlineEvents = props.events.filter((e) => e.data.meetingUrl);
+  const locationEvents = selectedLocation === "Online"
+    ? onlineEvents
+    : props.events.filter((e) => e.data.location?.name === selectedLocation);
+
+  const upcomingEvents = locationEvents.filter(
     (event) => !isEventExpired(event.data)
   );
-  const pastEvents = filteredEvents
+  const pastEvents = locationEvents
     .filter((event) => isEventExpired(event.data))
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
-  function renderCitySelector(): JSX.Element {
+  function renderLocationSelector(): JSX.Element {
     return (
       <Selector
-        options={cities}
-        value={selectedCity}
-        onChange={setSelectedCity}
+        options={locationNames}
+        value={selectedLocation}
+        onChange={setSelectedLocation}
       />
     );
   }
@@ -63,7 +65,7 @@ export default function EventList(props: EventListProps) {
       </div>;
     }
     return <div className="cnf-events--grid">
-      {pastEvents.length > 0 ? renderPastEvents() : <p>No past events in {selectedCity}.</p>}
+      {pastEvents.length > 0 ? renderPastEvents() : <p>No past events in {selectedLocation}.</p>}
     </div>;
   }
 
@@ -80,7 +82,7 @@ export default function EventList(props: EventListProps) {
 
   return (
     <>
-      {renderCitySelector()}
+      {renderLocationSelector()}
       {renderNavigation()}
       {renderEvents()}
     </>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -17,11 +17,14 @@ const event = defineCollection({
   schema: z.object({
     name: z.string(),
     date: z.date(),
-    city: z.string().nullable(),
     location: z.object({
+      id: z.number(),
+      name: z.string(),
+    }).nullable(),
+    venue: z.object({
       name: z.string().nullable(),
       url: z.string().nullable(),
-    }),
+    }).nullable(),
     slug: z.string(),
     description: z.string().nullable(),
     summary: z.string().nullable(),
@@ -30,6 +33,7 @@ const event = defineCollection({
       facebook: z.string().nullable(),
       meetup: z.string().nullable(),
     }),
+    meetingUrl: z.string().nullable(),
   }),
 });
 

--- a/src/layouts/EventCard.tsx
+++ b/src/layouts/EventCard.tsx
@@ -7,7 +7,7 @@ export default function EventCard({
   responsive = false,
 }: EventCardProps) {
   return (
-    <div className={`cnf-event ${responsive ? 'cnf-event--responsive' : ''} ${event.debate ? 'cnf-event--debate' : ''}`}>
+    <div className={`cnf-event ${responsive ? 'cnf-event--responsive' : ''}`}>
       <div className="cnf-event__poster">
         <a className="cnf-event__link" href={`/events/${event.slug}`}>
           <h3>{event.name}</h3>
@@ -20,9 +20,13 @@ export default function EventCard({
               {dateFormatter(new Date(event.date))}
             </li>
             <li className="cnf-event__location">
-              {event.location.url
-                ? <a href={event.location.url} target="_blank">{event.location.name}</a>
-                : <span>{event.location.name}</span>
+              {event.meetingUrl
+                ? <a href={event.meetingUrl} target="_blank">Online</a>
+                : event.venue?.url
+                  ? <a href={event.venue.url} target="_blank">{event.venue.name}</a>
+                  : event.venue?.name
+                    ? <span>{event.venue.name}</span>
+                    : null
               }
             </li>
           </ul>

--- a/src/lib/mailchimp.ts
+++ b/src/lib/mailchimp.ts
@@ -11,6 +11,7 @@ export interface EventDraft {
   name: string;
   date: string;
   slug: string;
+  meeting_url?: string | null;
   venue_name?: string | null;
   venue_url?: string | null;
 }
@@ -32,11 +33,13 @@ function buildEmailHtml(event: EventDraft): string {
   const eventUrl = `${SITE_URL}/events/${event.slug}`;
   const formattedDate = formatEventDate(event.date);
 
-  const venueHtml = event.venue_name
-    ? event.venue_url
-      ? `<br><a href="${event.venue_url}" style="color:${GREEN};text-decoration:underline;font-family:'Noto Sans',Arial,sans-serif;font-size:15px;">${event.venue_name}</a>`
-      : `<br><span style="color:${GREEN};">${event.venue_name}</span>`
-    : '';
+  const venueHtml = event.meeting_url
+    ? `<br><a href="${event.meeting_url}" style="color:${GREEN};text-decoration:underline;font-family:'Noto Sans',Arial,sans-serif;font-size:15px;">Join online</a>`
+    : event.venue_name
+      ? event.venue_url
+        ? `<br><a href="${event.venue_url}" style="color:${GREEN};text-decoration:underline;font-family:'Noto Sans',Arial,sans-serif;font-size:15px;">${event.venue_name}</a>`
+        : `<br><span style="color:${GREEN};">${event.venue_name}</span>`
+      : '';
 
   const igImg = `<img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDQ5IiBoZWlnaHQ9IjQ0OSIgdmlld0JveD0iMCAwIDQ0OSA0NDkiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0yMjQuMyAxMTBDMTYwLjggMTA5LjggMTA5LjIgMTYxLjIgMTA5IDIyNC43QzEwOC44IDI4OC4yIDE2MC4yIDMzOS44IDIyMy43IDM0MEMyODcuMiAzNDAuMiAzMzguOCAyODguOCAzMzkgMjI1LjNDMzM5LjIgMTYxLjggMjg3LjggMTEwLjIgMjI0LjMgMTEwWk0yMjMuNyAxNTAuNEMyNjQuOSAxNTAuMiAyOTguNCAxODMuNSAyOTguNiAyMjQuN0MyOTguOCAyNjUuOSAyNjUuNSAyOTkuNCAyMjQuMyAyOTkuNkMxODMuMSAyOTkuOCAxNDkuNiAyNjYuNSAxNDkuNCAyMjUuM0MxNDkuMiAxODQuMSAxODIuNSAxNTAuNiAyMjMuNyAxNTAuNFpNMzE3LjEgMTA1LjNDMzE3LjEgOTAuNDk5OSAzMjkuMSA3OC40OTk5IDM0My45IDc4LjQ5OTlDMzU4LjcgNzguNDk5OSAzNzAuNyA5MC40OTk5IDM3MC43IDEwNS4zQzM3MC43IDEyMC4xIDM1OC43IDEzMi4xIDM0My45IDEzMi4xQzMyOS4xIDEzMi4xIDMxNy4xIDEyMC4xIDMxNy4xIDEwNS4zWk00NDYuOCAxMzIuNUM0NDUuMSA5Ni42IDQzNi45IDY0LjggNDEwLjYgMzguNkMzODQuNCAxMi40IDM1Mi42IDQuMTk5OTUgMzE2LjcgMi4zOTk5NUMyNzkuNyAwLjI5OTk1MSAxNjguOCAwLjI5OTk1MSAxMzEuOCAyLjM5OTk1Qzk2IDQuMDk5OTUgNjQuMiAxMi4yOTk5IDM3LjkgMzguNUMxMS42IDY0LjcgMy41IDk2LjQ5OTkgMS43IDEzMi40Qy0wLjQgMTY5LjQgLTAuNCAyODAuMyAxLjcgMzE3LjNDMy40IDM1My4yIDExLjYgMzg1IDM3LjkgNDExLjJDNjQuMiA0MzcuNCA5NS45IDQ0NS42IDEzMS44IDQ0Ny40QzE2OC44IDQ0OS41IDI3OS43IDQ0OS41IDMxNi43IDQ0Ny40QzM1Mi42IDQ0NS43IDM4NC40IDQzNy41IDQxMC42IDQxMS4yQzQzNi44IDM4NSA0NDUgMzUzLjIgNDQ2LjggMzE3LjNDNDQ4LjkgMjgwLjMgNDQ4LjkgMTY5LjUgNDQ2LjggMTMyLjVaTTM5OSAzNTdDMzkxLjIgMzc2LjYgMzc2LjEgMzkxLjcgMzU2LjQgMzk5LjZDMzI2LjkgNDExLjMgMjU2LjkgNDA4LjYgMjI0LjMgNDA4LjZDMTkxLjcgNDA4LjYgMTIxLjYgNDExLjIgOTIuMiAzOTkuNkM3Mi42IDM5MS44IDU3LjUgMzc2LjcgNDkuNiAzNTdDMzcuOSAzMjcuNSA0MC42IDI1Ny41IDQwLjYgMjI0LjlDNDAuNiAxOTIuMyAzOCAxMjIuMiA0OS42IDkyLjc5OTlDNTcuNCA3My4xOTk5IDcyLjUgNTguMDk5OSA5Mi4yIDUwLjE5OTlDMTIxLjcgMzguNDk5OSAxOTEuNyA0MS4xOTk5IDIyNC4zIDQxLjE5OTlDMjU2LjkgNDEuMTk5OSAzMjcgMzguNTk5OSAzNTYuNCA1MC4xOTk5QzM3NiA1Ny45OTk5IDM5MS4xIDczLjA5OTkgMzk5IDkyLjc5OTlDNDEwLjcgMTIyLjMgNDA4IDE5Mi4zIDQwOCAyMjQuOUM0MDggMjU3LjUgNDEwLjcgMzI3LjYgMzk5IDM1N1oiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=" width="20" height="20" alt="Instagram" style="display:block;border:0;">`;
   const fbImg = `<img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMSIgdmlld0JveD0iMCAwIDUxMiA1MTEiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik01MTIgMjU2QzUxMiAxMTQuNiAzOTcuNCAwIDI1NiAwQzExNC42IDAgMCAxMTQuNiAwIDI1NkMwIDM3NiA4Mi43IDQ3Ni44IDE5NC4yIDUwNC41VjMzNC4ySDE0MS40VjI1NkgxOTQuMlYyMjIuM0MxOTQuMiAxMzUuMiAyMzMuNiA5NC44IDMxOS4yIDk0LjhDMzM1LjQgOTQuOCAzNjMuNCA5OCAzNzQuOSAxMDEuMlYxNzJDMzY4LjkgMTcxLjQgMzU4LjQgMTcxIDM0NS4zIDE3MUMzMDMuMyAxNzEgMjg3LjEgMTg2LjkgMjg3LjEgMjI4LjJWMjU2SDM3MC43TDM1Ni4zIDMzNC4ySDI4N1Y1MTAuMUM0MTMuOCA0OTQuOCA1MTIgMzg2LjkgNTEyIDI1NloiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=" width="20" height="20" alt="Facebook" style="display:block;border:0;">`;

--- a/src/loaders/events.ts
+++ b/src/loaders/events.ts
@@ -1,25 +1,6 @@
 import type { Loader } from 'astro/loaders';
 import { supabase } from '../lib/supabase';
 
-interface SupabaseEvent {
-  id: number;
-  name: string;
-  date: string;
-  venue_id: number | null;
-  venues: {
-    name: string;
-    url: string | null;
-    city: string;
-  } | null;
-  slug: string;
-  instagram: string | null;
-  facebook: string | null;
-  meetup: string | null;
-  description: string | null;
-  summary: string | null;
-  created_at: string | null;
-}
-
 export function eventsLoader(): Loader {
   return {
     name: 'events',
@@ -30,27 +11,37 @@ export function eventsLoader(): Loader {
 
       store.clear();
 
-      const { data, error } = await supabase
-        .from('events')
-        .select('*, venues(name, url, city)')
-        .order('date', { ascending: true })
-        .returns<SupabaseEvent[]>();
+      const [eventsResult, locationsResult] = await Promise.all([
+        supabase
+          .from('events')
+          .select('*, venues(name, url)')
+          .order('date', { ascending: true }),
+        supabase
+          .from('locations')
+          .select('id, name'),
+      ]);
 
-      if (error) {
-        throw new Error(`Failed to fetch events from Supabase: ${error.message}`);
+      if (eventsResult.error) {
+        throw new Error(`Failed to fetch events from Supabase: ${eventsResult.error.message}`);
       }
 
-      for (const event of data || []) {
+      if (locationsResult.error) {
+        throw new Error(`Failed to fetch locations from Supabase: ${locationsResult.error.message}`);
+      }
+
+      const locationsMap = new Map(locationsResult.data?.map((l) => [l.id, l]) ?? []);
+
+      for (const event of eventsResult.data || []) {
+        const venue = Array.isArray(event.venues) ? event.venues[0] ?? null : event.venues ?? null;
+        const location = event.location_id ? locationsMap.get(event.location_id) ?? null : null;
+
         store.set({
           id: event.id.toString(),
           data: {
             name: event.name,
             date: new Date(event.date),
-            city: event.venues?.city ?? null,
-            location: {
-              name: event.venues?.name ?? null,
-              url: event.venues?.url ?? null,
-            },
+            location,
+            venue: venue ? { name: venue.name, url: venue.url } : null,
             slug: event.slug,
             description: event.description,
             summary: event.summary,
@@ -59,6 +50,7 @@ export function eventsLoader(): Loader {
               facebook: event.facebook,
               meetup: event.meetup,
             },
+            meetingUrl: event.meeting_url,
           },
         });
       }

--- a/src/pages/admin/events.astro
+++ b/src/pages/admin/events.astro
@@ -24,7 +24,7 @@ const sorted = [...events].sort(
         <tr>
           <th>Name</th>
           <th>Date</th>
-          <th>City</th>
+          <th>Location</th>
           <th></th>
         </tr>
       </thead>
@@ -33,7 +33,7 @@ const sorted = [...events].sort(
           <tr>
             <td>{event.data.name}</td>
             <td>{formatBlogDate(event.data.date)}</td>
-            <td>{event.data.city ?? "—"}</td>
+            <td>{event.data.meetingUrl ? "Online" : event.data.location?.name ?? "—"}</td>
             <td><a href={`/admin/events/${event.data.slug}/edit`}>Edit</a></td>
           </tr>
         ))}

--- a/src/pages/admin/events/[slug]/edit.astro
+++ b/src/pages/admin/events/[slug]/edit.astro
@@ -10,7 +10,7 @@ const { slug } = Astro.params;
 
 const { data: event, error } = await supabase!
   .from("events")
-  .select("id, name, date, slug, venue_id, instagram, facebook, meetup, description, summary, venues(id, name, url, city)")
+  .select("id, name, date, slug, location_id, venue_id, meeting_url, instagram, facebook, meetup, description, summary, venues(id, name, url), locations(id, name)")
   .eq("slug", slug!)
   .single();
 
@@ -18,19 +18,20 @@ if (error || !event) {
   return Astro.redirect("/admin/events");
 }
 
-// Format date to datetime-local string (YYYY-MM-DDTHH:MM)
 const dateStr = new Date(event.date).toISOString().slice(0, 16);
 
 const venue = Array.isArray(event.venues) ? event.venues[0] : event.venues;
+const location = Array.isArray(event.locations) ? event.locations[0] : event.locations;
 
 const initialData: EventFormInitialData = {
   name: event.name,
   date: dateStr,
-  city: venue?.city ?? "Trieste",
+  locationId: location?.id,
   slug: event.slug,
   venueId: venue?.id,
   locationName: venue?.name,
   locationUrl: venue?.url ?? undefined,
+  meetingUrl: event.meeting_url ?? undefined,
   instagram: event.instagram ?? undefined,
   facebook: event.facebook ?? undefined,
   meetup: event.meetup ?? undefined,

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -24,21 +24,21 @@ const { event } = Astro.props;
       <span class="cnf-event-page__details-info"
         >{formatEventDate(new Date(event.data.date))}</span
       >
-      <a
-        href={event.data.location.url}
-        class="cnf-event-page__details-link"
-        target="_blank"
-      >
-        <img src="/map-pin.svg" />
-        {event.data.location.name}
-      </a>
       {
-        event.data.debate ? (
-          <span class="cnf-event-page__details-info">Debate</span>
-        ) : (
-          <span class="cnf-event-page__details-info">Discussion</span>
-        )
+        event.data.meetingUrl
+          ? <a href={event.data.meetingUrl} class="cnf-event-page__details-link" target="_blank">
+              Online
+            </a>
+          : event.data.venue?.url
+            ? <a href={event.data.venue.url} class="cnf-event-page__details-link" target="_blank">
+                <img src="/map-pin.svg" />
+                {event.data.venue.name}
+              </a>
+            : event.data.venue?.name
+              ? <span class="cnf-event-page__details-info">{event.data.venue.name}</span>
+              : null
       }
+      <span class="cnf-event-page__details-info">Discussion</span>
     </div>
     {event.data.description && (
       <div class="cnf-event-page__description">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -109,6 +109,7 @@ blockquote {
   cursor: pointer;
   font-family: "Noto Sans", sans-serif;
   font-size: 1.125rem;
+  font-weight: 400;
   transition: transition 0.1s ease;
   text-decoration: none;
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,27 +1,25 @@
 import type { CollectionEntry } from "astro:content";
 
-export const CITY = {
-  TRIESTE: "Trieste",
-} as const;
-export type City = typeof CITY[keyof typeof CITY];
-
 export type EventCollection = CollectionEntry<"event">;
 
 export type Event = {
   name: string;
   date: Date;
-  city?: string | null;
   location: {
+    id: number;
+    name: string;
+  } | null;
+  venue: {
     name: string | null;
     url: string | null;
-  };
+  } | null;
   slug: string;
   social: {
     instagram?: string | null;
     facebook?: string | null;
     meetup?: string | null;
   };
-  debate?: boolean;
+  meetingUrl: string | null;
 };
 
 export interface BannerProps {

--- a/src/utils/script.test.ts
+++ b/src/utils/script.test.ts
@@ -28,8 +28,10 @@ describe("isEventExpired", () => {
       slug: "test",
       name: "Test",
       date: new Date("2020-01-01"),
-      location: { name: "Test", url: "https://test.com" },
+      location: { id: 1, name: "Trieste" },
+      venue: { name: "Test Venue", url: "https://test.com" },
       social: { instagram: "https://instagram.com" },
+      meetingUrl: null,
     };
     expect(isEventExpired(pastEvent)).toBe(true);
   });
@@ -39,8 +41,10 @@ describe("isEventExpired", () => {
       slug: "test",
       name: "Test",
       date: new Date("2099-12-31"),
-      location: { name: "Test", url: "https://test.com" },
+      location: { id: 1, name: "Trieste" },
+      venue: { name: "Test Venue", url: "https://test.com" },
       social: { instagram: "https://instagram.com" },
+      meetingUrl: null,
     };
     expect(isEventExpired(futureEvent)).toBe(false);
   });

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7,18 +7,26 @@ CREATE TABLE users (
 
 ALTER TABLE users ENABLE ROW LEVEL SECURITY;
 
-CREATE TABLE venues (
+CREATE TABLE locations (
   id   SERIAL PRIMARY KEY,
-  name TEXT NOT NULL,
-  url  TEXT,
-  city TEXT NOT NULL,
-  UNIQUE(name, city)
+  name TEXT NOT NULL UNIQUE
+);
+
+INSERT INTO locations (name) VALUES ('Trieste'), ('Online');
+
+CREATE TABLE venues (
+  id          SERIAL PRIMARY KEY,
+  name        TEXT NOT NULL,
+  url         TEXT,
+  location_id INTEGER REFERENCES locations(id),
+  UNIQUE(name, location_id)
 );
 
 CREATE TABLE events (
   id          SERIAL PRIMARY KEY,
   name        TEXT NOT NULL,
   date        TIMESTAMP WITH TIME ZONE NOT NULL,
+  location_id INTEGER REFERENCES locations(id),
   venue_id    INTEGER REFERENCES venues(id),
   slug        TEXT UNIQUE NOT NULL,
   instagram   TEXT,
@@ -26,5 +34,6 @@ CREATE TABLE events (
   meetup      TEXT,
   description TEXT,
   summary     TEXT,
+  meeting_url TEXT,
   created_at  TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );


### PR DESCRIPTION
Refactor events to support online events with a dedicated locations table, location_id foreign keys, and meeting_url per event.

- Add locations table with Trieste and Online seed data
- Replace venues.city with venues.location_id FK
- Add events.location_id and events.meeting_url columns
- Restructure types, loader, actions, and form for new schema
- EventList filters by location name, with Online tab for meeting_url events
- Add PUBLIC_DEFAULT_MEETING_URL env var support
- Fix button font-weight inconsistency