### PR TITLE
fix: resolve test failures and deprecation hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ pnpm-debug.log*
 
 # Local Netlify folder
 .netlify
+
+# opencode configuration
+.opencode/
+opencode.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
 # Backlog
 
-- User registration: Create registration flow. Users would need to be approved before being granted access.
+- **User registration:** Create registration flow. Users would need to be approved before being granted access.
+
+# 2026-06-06
+
+## Fixed
+
+- **EventList.test.tsx**: Fixed `UpcomingEvent` mock prop name `events` → `event` to match the real component interface. Resolved 3 test failures.
+- **.gitignore**: Added `.opencode/` and `opencode.json` entries to allow local-only agent configurations to remain untracked by git.
+- **NewsletterForm.tsx**: Removed deprecated `FormEvent` import; uses `React.SyntheticEvent` inline instead.
+- **SuggestTopicForm.tsx**: Removed unused `formRef` variable.
+- **ContactForm.tsx, EventForm.tsx, LoginForm.tsx, NewsletterForm.tsx, PostForm.tsx**: Replaced deprecated `React.FormEvent` with `React.SyntheticEvent` (structurally identical — `FormEvent<T>` is a deprecated type alias for `SyntheticEvent<T>` in React 19). Eliminates all 5 remaining `ts(6385)` deprecation hints.

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -14,7 +14,7 @@ export default function ContactForm() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isFormSubmitted, setIsFormSubmitted] = useState(false);
 
-  async function onSubmit(e: React.FormEvent) {
+  async function onSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
 
     if (!isValidEmail(email)) {

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -56,7 +56,7 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
   const isNewVenue = selectedVenueId === NEW_VENUE;
   const selectedVenue = venues.find((v) => String(v.id) === selectedVenueId);
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     setStatus("loading");
     setErrorMessage("");

--- a/src/components/EventList/EventList.test.tsx
+++ b/src/components/EventList/EventList.test.tsx
@@ -13,10 +13,9 @@ vi.mock("../Selector/Selector", () => ({
 }));
 
 vi.mock("../UpcomingEvent", () => ({
-  default: ({ events }: { events: { name: string }[] }) => {
-    const current = events.find(() => true);
-    return <div data-testid="upcoming-event">{current?.name}</div>;
-  },
+  default: ({ event }: { event: { name: string } }) => (
+    <div data-testid="upcoming-event">{event?.name}</div>
+  ),
 }));
 
 vi.mock("../../layouts/EventCard", () => ({

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -5,7 +5,7 @@ export default function LoginForm() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
     setError(null);
     setLoading(true);

--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FormEvent, type JSX } from "react";
+import { useEffect, useRef, useState, type JSX } from "react";
 import "../styles/form.css";
 
 export default function NewsletterForm() {
@@ -11,7 +11,7 @@ export default function NewsletterForm() {
 
   useEffect(() => localStorage.removeItem("newsletter_subscribed"), []);
 
-  async function onSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+  async function onSubmit(e: React.SyntheticEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault();
     setIsLoading(true);
     const email = emailRef.current?.value.trim();

--- a/src/components/PostForm/PostForm.tsx
+++ b/src/components/PostForm/PostForm.tsx
@@ -18,7 +18,7 @@ export default function PostForm({ mode, initialData }: PostFormProps) {
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [errorMessage, setErrorMessage] = useState("");
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     setStatus("loading");
     setErrorMessage("");

--- a/src/components/SuggestTopicForm.tsx
+++ b/src/components/SuggestTopicForm.tsx
@@ -8,7 +8,6 @@ export default function TopicSuggestForm() {
   const [isFormSubmitted, setIsFormSubmitted] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [topics, setTopics] = useState<string[]>([]);
-  const formRef = useRef<HTMLFormElement>(null);
   const topicRef = useRef<HTMLInputElement>(null);
 
   async function onSubmit(): Promise<void> {


### PR DESCRIPTION
- Fix `UpcomingEvent` mock prop name in `EventList.test.tsx` (`events` → `event`)
- Replace deprecated `React.FormEvent` with `React.SyntheticEvent` in 5 forms
- Remove unused `formRef` from `SuggestTopicForm.tsx`
- Remove deprecated `FormEvent` import from `NewsletterForm.tsx`
- Add `.opencode/` and `opencode.json` to `.gitignore` for local agent configs
- Update `CHANGELOG.md`