### PR TITLE
feat: admin console improvements

### DIFF
--- a/src/components/AdminHeader.astro
+++ b/src/components/AdminHeader.astro
@@ -1,5 +1,4 @@
 ---
-const { pathname } = Astro.url;
 ---
 
 <style>
@@ -29,28 +28,27 @@ const { pathname } = Astro.url;
     width: 45px;
     height: 50px;
   }
+
+  .cnf-nav__brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .cnf-nav__admin-label {
+  }
 </style>
 
 <header>
   <nav class="cnf-nav">
-    <div>
-      <a class="cnf-nav__link" href="/">
+    <div class="cnf-nav__brand">
+      <a class="cnf-nav__link" href="/admin/">
         <img class="cnf-nav__link--svg" src="/cnf-logo.svg" />
       </a>
+      <a class="cnf-nav__link cnf-nav__admin-label" href="/admin/">Admin</a>
     </div>
     <div>
-      <a
-        class={`cnf-nav__link ${pathname.startsWith("/about") ? "tab-active" : ""}`}
-        href="/about/">About</a
-      >
-      <a
-        class={`cnf-nav__link ${pathname.startsWith("/events") ? "tab-active" : ""}`}
-        href="/events/">Events</a
-      >
-      <a
-        class={`cnf-nav__link ${pathname.startsWith("/blog") || pathname.startsWith("/post") ? "tab-active" : ""}`}
-        href="/blog/">Blog</a
-      >
+      <a class="cnf-nav__link" href="/api/logout">Log out</a>
     </div>
   </nav>
 </header>

--- a/src/components/AdminSidebar.astro
+++ b/src/components/AdminSidebar.astro
@@ -1,0 +1,63 @@
+---
+const { pathname } = Astro.url;
+---
+
+<style>
+  .cnf-admin-sidebar {
+    width: 220px;
+    min-height: 100%;
+    padding: 0 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    border-right: 1px solid hsl(var(--color-grey) / 0.2);
+  }
+
+  @media (max-width: 768px) {
+    .cnf-admin-sidebar {
+      width: 100%;
+      min-height: unset;
+      flex-direction: row;
+      padding: 0.5rem 1rem;
+      border-right: none;
+      border-bottom: 1px solid hsl(var(--color-grey) / 0.2);
+      gap: 0.5rem;
+    }
+  }
+
+  .cnf-admin-sidebar__link {
+    display: block;
+    text-decoration: none;
+    color: hsl(var(--color-grey));
+    font-family: "Playfair Display", serif;
+    padding: 0.6rem 0.75rem;
+    transition: background-color 0.15s, color 0.15s;
+  }
+
+  .cnf-admin-sidebar__link:hover {
+    color: hsl(var(--color-green));
+  }
+
+  .cnf-admin-sidebar__link--active {
+    color: hsl(var(--color-green));
+    text-decoration: underline;
+    text-decoration-color: hsl(var(--color-green));
+    text-decoration-thickness: 1px;
+    text-underline-offset: 6px;
+  }
+</style>
+
+<aside class="cnf-admin-sidebar">
+  <a
+    class={`cnf-admin-sidebar__link ${pathname === "/admin" || pathname === "/admin/" ? "cnf-admin-sidebar__link--active" : ""}`}
+    href="/admin/">Dashboard</a
+  >
+  <a
+    class={`cnf-admin-sidebar__link ${pathname.startsWith("/admin/events") || pathname === "/admin/create-event" ? "cnf-admin-sidebar__link--active" : ""}`}
+    href="/admin/events">Events</a
+  >
+  <a
+    class={`cnf-admin-sidebar__link ${pathname.startsWith("/admin/posts") || pathname === "/admin/create-post" ? "cnf-admin-sidebar__link--active" : ""}`}
+    href="/admin/posts">Posts</a
+  >
+</aside>

--- a/src/components/EventForm/EventForm.test.tsx
+++ b/src/components/EventForm/EventForm.test.tsx
@@ -69,7 +69,7 @@ describe("EventForm (create mode)", () => {
     });
   });
 
-  it("shows success state when event is created", async () => {
+  it("shows success message when event is created", async () => {
     mockCreateEvent.mockResolvedValue({ data: { success: true } });
     render(<EventForm mode="create" />);
 
@@ -136,7 +136,7 @@ describe("EventForm (edit mode)", () => {
     });
   });
 
-  it("shows success state with back link after update", async () => {
+  it("shows success message after update", async () => {
     mockUpdateEvent.mockResolvedValue({ data: { success: true } });
     render(<EventForm mode="edit" initialData={sampleInitialData} />);
 
@@ -145,10 +145,6 @@ describe("EventForm (edit mode)", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/event updated successfully/i)).toBeInTheDocument();
-      expect(screen.getByRole("link", { name: /back to events/i })).toHaveAttribute(
-        "href",
-        "/admin/events"
-      );
     });
   });
 

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -95,19 +95,9 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
 
   if (status === "success") {
     if (mode === "edit") {
-      return (
-        <>
-          <p>Event updated successfully!</p>
-          <a href="/admin/events">Back to events</a>
-        </>
-      );
+      return <p>Event updated successfully!</p>;
     }
-    return (
-      <>
-        <p>Event created successfully!</p>
-        <a href="/events">See all events</a>
-      </>
-    );
+    return <p>Event created successfully!</p>;
   }
 
   return (

--- a/src/components/PostForm/PostForm.test.tsx
+++ b/src/components/PostForm/PostForm.test.tsx
@@ -58,7 +58,7 @@ describe("PostForm (create mode)", () => {
     });
   });
 
-  it("shows success state when post is created", async () => {
+  it("shows success message when post is created", async () => {
     mockCreatePost.mockResolvedValue({ data: { success: true } });
     render(<PostForm mode="create" />);
 
@@ -66,10 +66,6 @@ describe("PostForm (create mode)", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/post created successfully/i)).toBeInTheDocument();
-      expect(screen.getByRole("link", { name: /back to posts/i })).toHaveAttribute(
-        "href",
-        "/admin/posts"
-      );
     });
   });
 });
@@ -111,7 +107,7 @@ describe("PostForm (edit mode)", () => {
     });
   });
 
-  it("shows success state with back link after update", async () => {
+  it("shows success message after update", async () => {
     mockUpdatePost.mockResolvedValue({ data: { success: true } });
     render(<PostForm mode="edit" initialData={sampleInitialData} />);
 
@@ -119,10 +115,6 @@ describe("PostForm (edit mode)", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/post updated successfully/i)).toBeInTheDocument();
-      expect(screen.getByRole("link", { name: /back to posts/i })).toHaveAttribute(
-        "href",
-        "/admin/posts"
-      );
     });
   });
 });

--- a/src/components/PostForm/PostForm.tsx
+++ b/src/components/PostForm/PostForm.tsx
@@ -45,12 +45,7 @@ export default function PostForm({ mode, initialData }: PostFormProps) {
   };
 
   if (status === "success") {
-    return (
-      <>
-        <p>{mode === "edit" ? "Post updated" : "Post created"} successfully!</p>
-        <a href="/admin/posts">Back to posts</a>
-      </>
-    );
+    return <p>{mode === "edit" ? "Post updated" : "Post created"} successfully!</p>;
   }
 
   return (

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -1,5 +1,6 @@
 ---
-import Header from "../components/Header.astro";
+import AdminHeader from "../components/AdminHeader.astro";
+import AdminSidebar from "../components/AdminSidebar.astro";
 import "../styles/global.css";
 const { pageTitle } = Astro.props;
 ---
@@ -16,12 +17,43 @@ const { pageTitle } = Astro.props;
       href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Uncial+Antiqua&display=swap"
       rel="stylesheet"
     />
-    <title>{pageTitle} | Admin</title>
+    <title>Admin | Club na Fealsúnachta</title>
   </head>
-  <body>
-    <Header showNav={false} />
-    <main class="content">
-      <slot />
-    </main>
+  <body class="cnf-admin-body">
+    <AdminHeader />
+    <div class="cnf-admin-shell">
+      <AdminSidebar />
+      <main class="cnf-admin-content">
+        <slot />
+      </main>
+    </div>
   </body>
 </html>
+
+<style>
+  .cnf-admin-body {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .cnf-admin-shell {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    max-width: 1200px;
+    margin: 0 auto;
+    width: 100%;
+  }
+
+  @media (max-width: 768px) {
+    .cnf-admin-shell {
+      flex-direction: column;
+    }
+  }
+
+  .cnf-admin-content {
+    flex: 1;
+    overflow-y: auto;
+  }
+</style>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,10 +20,10 @@ export async function verifyPassword(password: string, stored: string): Promise<
   return hash.length === storedBuffer.length && timingSafeEqual(hash, storedBuffer);
 }
 
-export function createSessionToken(email: string): string {
+export function createSessionToken(email: string, isAdmin: boolean): string {
   const secret = process.env.JWT_SECRET;
   if (!secret) throw new Error("JWT_SECRET is not set");
-  return jwt.sign({ email }, secret, { expiresIn: "30d" });
+  return jwt.sign({ email, isAdmin }, secret, { expiresIn: "30d" });
 }
 
 export function getSessionToken(request: Request): string | undefined {
@@ -31,11 +31,11 @@ export function getSessionToken(request: Request): string | undefined {
   return cookie.match(/(?:^|;\s*)session=([^;]+)/)?.[1];
 }
 
-export function verifySessionToken(token: string): { email: string } | null {
+export function verifySessionToken(token: string): { email: string; isAdmin: boolean } | null {
   const secret = process.env.JWT_SECRET;
   if (!secret) return null;
   try {
-    const payload = jwt.verify(token, secret) as { email: string };
+    const payload = jwt.verify(token, secret) as { email: string; isAdmin: boolean };
     return payload;
   } catch {
     return null;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,7 +10,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   if (token) {
     const payload = verifySessionToken(token);
-    if (payload) return next();
+    if (payload?.isAdmin) return next();
   }
 
   return context.redirect("/login");

--- a/src/pages/admin/create-event.astro
+++ b/src/pages/admin/create-event.astro
@@ -7,7 +7,10 @@ import "../../styles/form.css";
 
 <AdminLayout pageTitle="Create Event">
   <section class="cnf-section">
-    <h1>Create event</h1>
+    <div class="cnf-admin-header">
+      <h1>Create event</h1>
+      <a href="/admin/events">Back to events</a>
+    </div>
     <EventForm mode="create" client:load />
   </section>
 </AdminLayout>

--- a/src/pages/admin/create-post.astro
+++ b/src/pages/admin/create-post.astro
@@ -7,7 +7,10 @@ import "../../styles/form.css";
 
 <AdminLayout pageTitle="Create Post">
   <section class="cnf-section">
-    <h1>Create post</h1>
+    <div class="cnf-admin-header">
+      <h1>Create post</h1>
+      <a href="/admin/posts">Back to posts</a>
+    </div>
     <PostForm mode="create" client:load />
   </section>
 </AdminLayout>

--- a/src/pages/admin/events.astro
+++ b/src/pages/admin/events.astro
@@ -13,7 +13,7 @@ const sorted = [...events].sort(
 
 <AdminLayout pageTitle="Events">
   <section class="cnf-section">
-    <div class="cnf-admin-events__header">
+    <div class="cnf-admin-header">
       <h1>Events</h1>
       <a href="/admin/create-event" class="cnf-button cnf-button__gold">
         <span class="cnf-button__text">Create event</span>
@@ -44,13 +44,6 @@ const sorted = [...events].sort(
 </AdminLayout>
 
 <style>
-  .cnf-admin-events__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 1.5rem;
-  }
-
   .cnf-admin-events__table {
     width: 100%;
     border-collapse: collapse;

--- a/src/pages/admin/events/[slug]/edit.astro
+++ b/src/pages/admin/events/[slug]/edit.astro
@@ -42,19 +42,10 @@ const initialData: EventFormInitialData = {
 
 <AdminLayout pageTitle={`Edit: ${event.name}`}>
   <section class="cnf-section">
-    <div class="cnf-admin-events__header">
+    <div class="cnf-admin-header">
       <h1>Edit event</h1>
       <a href="/admin/events">Back to events</a>
     </div>
     <EventForm mode="edit" initialData={initialData} client:load />
   </section>
 </AdminLayout>
-
-<style>
-  .cnf-admin-events__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 1.5rem;
-  }
-</style>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,25 +1,61 @@
 ---
 export const prerender = false;
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import { getCollection } from "astro:content";
+import type { EventCollection } from "../../types/types";
+
+const events = (await getCollection("event")) as EventCollection[];
+const now = new Date();
+const upcomingEvents = events.filter((e) => e.data.date >= now);
+const posts = await getCollection("blog");
 ---
 
 <AdminLayout pageTitle="Admin">
   <section class="cnf-section">
-    <h1>Admin</h1>
-    <nav class="cnf-admin-nav">
-      <a href="/admin/events">View events</a>
-      <a href="/admin/posts">View posts</a>
-    </nav>
-    <a href="/">Home</a>
-    <a href="/api/logout">Log out</a>
+    <h1>Dashboard</h1>
+    <div class="cnf-dashboard-stats">
+      <div class="cnf-stat-card">
+        <span class="cnf-stat-card__number">{events.length}</span>
+        <span class="cnf-stat-card__label">Total events</span>
+      </div>
+      <div class="cnf-stat-card">
+        <span class="cnf-stat-card__number">{upcomingEvents.length}</span>
+        <span class="cnf-stat-card__label">Upcoming events</span>
+      </div>
+      <div class="cnf-stat-card">
+        <span class="cnf-stat-card__number">{posts.length}</span>
+        <span class="cnf-stat-card__label">Total posts</span>
+      </div>
+    </div>
+    <a href="/">View site</a>
   </section>
 </AdminLayout>
 
 <style>
-  .cnf-admin-nav {
+  .cnf-dashboard-stats {
     display: flex;
-    gap: 1rem;
+    gap: 1.5rem;
     flex-wrap: wrap;
+    margin: 1.5rem 0;
   }
 
+  .cnf-stat-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .cnf-stat-card__number {
+    font-family: "Playfair Display", serif;
+    font-size: 2rem;
+    color: hsl(var(--color-green));
+  }
+
+  .cnf-stat-card__label {
+    font-size: 0.85rem;
+    color: hsl(var(--color-grey));
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
 </style>

--- a/src/pages/api/login.ts
+++ b/src/pages/api/login.ts
@@ -25,7 +25,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   const { data: user } = await supabaseAdmin
     .from("users")
-    .select("password_hash")
+    .select("password_hash, is_admin")
     .eq("email", email)
     .single();
 
@@ -38,7 +38,7 @@ export const POST: APIRoute = async ({ request }) => {
     return json({ error: "Invalid email or password" }, 401);
   }
 
-  const token = createSessionToken(email);
+  const token = createSessionToken(email, user.is_admin);
   const cookie = `session=${token}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=2592000`;
 
   return new Response(JSON.stringify({ success: true }), {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -62,6 +62,13 @@ select {
   margin: 0 auto 4rem auto;
 }
 
+.cnf-admin-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
 a {
   color: hsl(var(--color-green));
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2,6 +2,7 @@ CREATE TABLE users (
   id            UUID DEFAULT gen_random_uuid() PRIMARY KEY,
   email         TEXT UNIQUE NOT NULL,
   password_hash TEXT NOT NULL,
+  is_admin      BOOLEAN DEFAULT FALSE NOT NULL,
   created_at    TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 


### PR DESCRIPTION
 - Added a dedicated AdminLayout with a persistent header (AdminHeader) and sidebar navigation (AdminSidebar), replacing the ad-hoc nav that was inline on each page
  - Added a dashboard page (/admin) with stat cards showing total events, upcoming events, and total posts
  - Sidebar highlights the active section based on the current URL
  - Updated EventForm and PostForm success states to show a message only (navigation is now handled by the sidebar)
  - Updated tests to reflect the removed success-state back links