### PR TITLE
Add unverified-signup retention cleanup

### DIFF
--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 const pageTitle = "Privacy Policy";
-const lastUpdated = "23 July 2026";
+const lastUpdated = "29 July 2026";
 ---
 
 <BaseLayout pageTitle={pageTitle}>
@@ -83,7 +83,9 @@ const lastUpdated = "23 July 2026";
 
       <h2>How long we keep it</h2>
       <p>
-        Member accounts are kept until you ask us to delete them.
+        Member accounts are kept until you ask us to delete them. If you
+        start creating an account but never confirm your email address, that
+        unconfirmed signup is automatically deleted after about 30 days.
         Newsletter addresses are kept until you unsubscribe. Contact form
         and topic suggestion messages aren't stored in a database, but the
         email itself remains in our inbox until we delete it.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -54,3 +54,25 @@ CREATE TABLE events (
   meeting_url TEXT,
   created_at  TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
+-- Data retention: an unverified signup never became a real member, so
+-- there's no ongoing purpose to justify keeping the email + password hash
+-- (GDPR storage limitation, Art. 5(1)(e)). Admin-created members are
+-- auto-verified on insert (see createAccount(..., autoVerify)), so this
+-- only ever touches abandoned public sign-ups.
+CREATE OR REPLACE FUNCTION delete_stale_unverified_members()
+RETURNS void
+LANGUAGE sql
+AS $$
+  DELETE FROM members
+  WHERE email_verified_at IS NULL
+    AND created_at < NOW() - INTERVAL '30 days';
+$$;
+
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+
+SELECT cron.schedule(
+  'delete-stale-unverified-members',
+  '0 3 * * *', -- daily at 03:00 UTC
+  $$SELECT delete_stale_unverified_members()$$
+);


### PR DESCRIPTION
## Summary
- Adds a `pg_cron` job (`delete_stale_unverified_members`, daily 03:00 UTC) that deletes member signups that never confirmed their email after 30 days — GDPR storage-limitation cleanup for the `members` table.
- Documents the 30-day retention period in the privacy policy.

## Notes
- Requires the `pg_cron` extension enabled in the Supabase dashboard (already done and SQL run against production, confirmed registered via `SELECT * FROM cron.job`).
- Admin-created members are excluded since they're auto-verified on insert.

## Test plan
- [x] `npx vitest run` passes (80/80)
- [x] Cron job confirmed registered in production Supabase