### PR TITLE
Profile editing: username, full name, password, custom checkbox

### DIFF
--- a/src/actions/changePassword.ts
+++ b/src/actions/changePassword.ts
@@ -1,0 +1,64 @@
+import { defineAction, ActionError } from 'astro:actions';
+import { verifySessionToken, verifyPassword, hashPassword } from '../lib/auth';
+import { validatePassword } from '../utils/validation';
+import { supabaseAdmin } from '../lib/supabase';
+
+export const changePassword = defineAction({
+  accept: 'form',
+  handler: async (formData, context) => {
+    const token = context.cookies.get('session')?.value;
+    const payload = token ? verifySessionToken(token) : null;
+    if (!payload) {
+      throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
+    }
+
+    const currentPassword = formData.get('current_password') as string;
+    const newPassword = formData.get('new_password') as string;
+    const confirmPassword = formData.get('confirm_password') as string;
+
+    if (!currentPassword || !newPassword || !confirmPassword) {
+      throw new ActionError({ code: 'BAD_REQUEST', message: 'All fields are required' });
+    }
+
+    const passwordError = validatePassword(newPassword);
+    if (passwordError) {
+      throw new ActionError({ code: 'BAD_REQUEST', message: passwordError });
+    }
+
+    if (newPassword !== confirmPassword) {
+      throw new ActionError({ code: 'BAD_REQUEST', message: 'Passwords do not match' });
+    }
+
+    if (!supabaseAdmin) {
+      throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Supabase not configured' });
+    }
+
+    const { data: member } = await supabaseAdmin
+      .from('members')
+      .select('password_hash')
+      .eq('email', payload.email)
+      .single();
+
+    if (!member) {
+      throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
+    }
+
+    const valid = await verifyPassword(currentPassword, member.password_hash);
+    if (!valid) {
+      throw new ActionError({ code: 'UNAUTHORIZED', message: 'Current password is incorrect' });
+    }
+
+    const password_hash = await hashPassword(newPassword);
+
+    const { error } = await supabaseAdmin
+      .from('members')
+      .update({ password_hash })
+      .eq('email', payload.email);
+
+    if (error) {
+      throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to update password' });
+    }
+
+    return { success: true };
+  },
+});

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -2,6 +2,8 @@ import { createEvent, updateEvent, getLocations, getVenues } from './events';
 import { createPost, updatePost } from './posts';
 import { createMember } from './members';
 import { signup } from './signup';
+import { changePassword } from './changePassword';
+import { updateUsername } from './updateUsername';
 
 export const server = {
   createEvent,
@@ -12,4 +14,6 @@ export const server = {
   updatePost,
   createMember,
   signup,
+  changePassword,
+  updateUsername,
 };

--- a/src/actions/updateUsername.ts
+++ b/src/actions/updateUsername.ts
@@ -1,0 +1,60 @@
+import { defineAction, ActionError } from 'astro:actions';
+import { verifySessionToken } from '../lib/auth';
+import { validateUsername, validateFullName } from '../utils/validation';
+import { escapeLikePattern } from '../lib/username';
+import { supabaseAdmin } from '../lib/supabase';
+
+export const updateUsername = defineAction({
+  accept: 'form',
+  handler: async (formData, context) => {
+    const token = context.cookies.get('session')?.value;
+    const payload = token ? verifySessionToken(token) : null;
+    if (!payload) {
+      throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
+    }
+
+    const username = (formData.get('username') as string)?.trim() ?? '';
+    const fullName = (formData.get('full_name') as string)?.trim() ?? '';
+    const displayFullName = formData.get('display_full_name') === 'true';
+
+    if (!username) {
+      throw new ActionError({ code: 'BAD_REQUEST', message: 'Username is required' });
+    }
+
+    const usernameError = validateUsername(username);
+    if (usernameError) {
+      throw new ActionError({ code: 'BAD_REQUEST', message: usernameError });
+    }
+
+    const fullNameError = validateFullName(fullName);
+    if (fullNameError) {
+      throw new ActionError({ code: 'BAD_REQUEST', message: fullNameError });
+    }
+
+    if (!supabaseAdmin) {
+      throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Supabase not configured' });
+    }
+
+    const { data: existingUsername } = await supabaseAdmin
+      .from('members')
+      .select('id')
+      .ilike('username', escapeLikePattern(username))
+      .neq('email', payload.email)
+      .single();
+
+    if (existingUsername) {
+      throw new ActionError({ code: 'CONFLICT', message: 'That username is already taken' });
+    }
+
+    const { error } = await supabaseAdmin
+      .from('members')
+      .update({ username, full_name: fullName || null, display_full_name: displayFullName })
+      .eq('email', payload.email);
+
+    if (error) {
+      throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to update info' });
+    }
+
+    return { success: true, username, full_name: fullName || null, display_full_name: displayFullName };
+  },
+});

--- a/src/components/AccountForm/AccountForm.test.tsx
+++ b/src/components/AccountForm/AccountForm.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AccountForm from "./AccountForm";
+
+const mockUpdateUsername = vi.fn();
+const mockChangePassword = vi.fn();
+
+vi.mock("astro:actions", () => ({
+  actions: {
+    updateUsername: (...args: unknown[]) => mockUpdateUsername(...args),
+    changePassword: (...args: unknown[]) => mockChangePassword(...args),
+  },
+}));
+
+function renderForm() {
+  render(<AccountForm initialUsername="oldname" initialFullName={null} initialDisplayFullName={false} />);
+}
+
+describe("AccountForm", () => {
+  beforeEach(() => {
+    mockUpdateUsername.mockReset();
+    mockChangePassword.mockReset();
+  });
+
+  it("renders the username, full name and password fields, and a single save button", () => {
+    render(<AccountForm initialUsername="oldname" initialFullName="Old Name" initialDisplayFullName={true} />);
+    expect(screen.getByLabelText("Username")).toHaveValue("oldname");
+    expect(screen.getByLabelText("Full name")).toHaveValue("Old Name");
+    expect(screen.getByLabelText(/show my full name instead of my username/i)).toBeChecked();
+    expect(screen.getByLabelText(/current password/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^new password$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm new password/i)).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /save/i })).toHaveLength(1);
+  });
+
+  it("blocks submission and shows a field error when the username is invalid", async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText("Username"), { target: { value: "a" } });
+    fireEvent.submit(document.querySelector("form")!);
+
+    await waitFor(() => {
+      expect(screen.getByText(/please enter a valid username/i)).toBeInTheDocument();
+    });
+    expect(mockUpdateUsername).not.toHaveBeenCalled();
+  });
+
+  it("saves the username without touching the password when the password fields are left blank", async () => {
+    mockUpdateUsername.mockResolvedValue({ data: { success: true } });
+    renderForm();
+
+    fireEvent.submit(document.querySelector("form")!);
+
+    await waitFor(() => {
+      expect(screen.getByText(/your info has been updated/i)).toBeInTheDocument();
+    });
+    expect(mockUpdateUsername).toHaveBeenCalledTimes(1);
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it("does not treat an autofilled current-password field alone as a password-change request", async () => {
+    mockUpdateUsername.mockResolvedValue({ data: { success: true } });
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText(/current password/i), { target: { value: "OldPassword1" } });
+    fireEvent.submit(document.querySelector("form")!);
+
+    await waitFor(() => {
+      expect(screen.getByText(/your info has been updated/i)).toBeInTheDocument();
+    });
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it("requires the current password and a matching confirmation once a new password is entered", async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: "NewPassword1" } });
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: "Different1" } });
+    fireEvent.submit(document.querySelector("form")!);
+
+    await waitFor(() => {
+      expect(screen.getByText(/enter your current password/i)).toBeInTheDocument();
+      expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument();
+    });
+    expect(mockUpdateUsername).not.toHaveBeenCalled();
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it("saves both username and password in one submit when password fields are filled in", async () => {
+    mockUpdateUsername.mockResolvedValue({ data: { success: true } });
+    mockChangePassword.mockResolvedValue({ data: { success: true } });
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText(/current password/i), { target: { value: "OldPassword1" } });
+    fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: "NewPassword1" } });
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: "NewPassword1" } });
+    fireEvent.submit(document.querySelector("form")!);
+
+    await waitFor(() => {
+      expect(screen.getByText(/your info and password have been updated/i)).toBeInTheDocument();
+    });
+    expect(mockUpdateUsername).toHaveBeenCalledTimes(1);
+    expect(mockChangePassword).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the username as saved and explains the password failure when only the password action errors", async () => {
+    mockUpdateUsername.mockResolvedValue({ data: { success: true } });
+    mockChangePassword.mockResolvedValue({ error: { message: "Current password is incorrect" } });
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText(/current password/i), { target: { value: "WrongPassword1" } });
+    fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: "NewPassword1" } });
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: "NewPassword1" } });
+    fireEvent.submit(document.querySelector("form")!);
+
+    await waitFor(() => {
+      expect(screen.getByText(/your info has been updated\. password unchanged: current password is incorrect/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("form")).toBeInTheDocument();
+  });
+
+  it("disables submit button while submitting", async () => {
+    mockUpdateUsername.mockReturnValue(new Promise(() => {}));
+    renderForm();
+
+    fireEvent.submit(document.querySelector("form")!);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+    });
+  });
+});

--- a/src/components/AccountForm/AccountForm.tsx
+++ b/src/components/AccountForm/AccountForm.tsx
@@ -1,0 +1,198 @@
+import { useState } from "react";
+import { actions } from "astro:actions";
+import { validateUsername, validateFullName, validatePassword } from "../../utils/validation";
+import Checkbox from "../Checkbox/Checkbox";
+import "../../styles/form.css";
+
+type FieldName = "username" | "full_name" | "current_password" | "new_password" | "confirm_password";
+type FieldErrors = Partial<Record<FieldName, string>>;
+
+interface Props {
+  initialUsername: string;
+  initialFullName: string | null;
+  initialDisplayFullName: boolean;
+}
+
+export default function AccountForm({ initialUsername, initialFullName, initialDisplayFullName }: Props) {
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [message, setMessage] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const name = e.target.name as FieldName;
+    setFieldErrors((prev) => (prev[name] ? { ...prev, [name]: undefined } : prev));
+  }
+
+  async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setMessage(null);
+
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const username = formData.get("username")?.toString().trim() ?? "";
+    const fullName = formData.get("full_name")?.toString().trim() ?? "";
+    const currentPassword = formData.get("current_password")?.toString() ?? "";
+    const newPassword = formData.get("new_password")?.toString() ?? "";
+    const confirmPassword = formData.get("confirm_password")?.toString() ?? "";
+
+    // A filled-in "new password" is what signals intent to change the password, not
+    // "current password" — password managers autofill current-password fields on page
+    // load, which would otherwise make an untouched form look like a password-change
+    // attempt.
+    const wantsPasswordChange = newPassword !== "";
+
+    const errors: FieldErrors = {
+      username: validateUsername(username) ?? undefined,
+      full_name: validateFullName(fullName) ?? undefined,
+      current_password: wantsPasswordChange && !currentPassword ? "Enter your current password" : undefined,
+      new_password: wantsPasswordChange ? validatePassword(newPassword) ?? undefined : undefined,
+      confirm_password: wantsPasswordChange && newPassword !== confirmPassword ? "Passwords do not match" : undefined,
+    };
+    setFieldErrors(errors);
+
+    if (Object.values(errors).some(Boolean)) {
+      return;
+    }
+
+    setStatus("loading");
+
+    try {
+      const [usernameResult, passwordResult] = await Promise.all([
+        actions.updateUsername(formData),
+        wantsPasswordChange ? actions.changePassword(formData) : Promise.resolve(null),
+      ]);
+
+      const usernameError = usernameResult.error?.message ?? null;
+      const passwordError = wantsPasswordChange ? passwordResult?.error?.message ?? null : null;
+
+      if (!usernameError && !passwordError) {
+        setStatus("success");
+        setMessage(wantsPasswordChange ? "Your info and password have been updated." : "Your info has been updated.");
+        return;
+      }
+
+      setStatus("error");
+
+      if (!wantsPasswordChange) {
+        setMessage(usernameError);
+        return;
+      }
+
+      if (!usernameError) {
+        setMessage(`Your info has been updated. Password unchanged: ${passwordError}`);
+      } else if (!passwordError) {
+        setMessage(`Your password has been updated. Info unchanged: ${usernameError}`);
+      } else {
+        setMessage(`Info unchanged: ${usernameError} Password unchanged: ${passwordError}`);
+      }
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "Something went wrong");
+      setStatus("error");
+    }
+  }
+
+  if (status === "success") {
+    return <p>{message}</p>;
+  }
+
+  return (
+    <form className="cnf-form" onSubmit={handleSubmit} aria-label="Account settings form" noValidate>
+      {message && <div className="cnf-form__message--error">{message}</div>}
+
+      <fieldset className="cnf-form__fieldset">
+        <legend className="cnf-visually-hidden">Profile details</legend>
+        <div className="cnf-form__group">
+          <label className="cnf-form__label" htmlFor="username">Username</label>
+          <input
+            id="username"
+            type="text"
+            name="username"
+            className="cnf-form__input"
+            defaultValue={initialUsername}
+            required
+            onChange={handleChange}
+            aria-invalid={!!fieldErrors.username}
+          />
+          <p className="cnf-form__hint">3-20 characters: letters, numbers, and underscores only.</p>
+          {fieldErrors.username && <div className="cnf-form__message--error">{fieldErrors.username}</div>}
+        </div>
+
+        <div className="cnf-form__group">
+          <label className="cnf-form__label" htmlFor="full_name">Full name</label>
+          <input
+            id="full_name"
+            type="text"
+            name="full_name"
+            className="cnf-form__input"
+            defaultValue={initialFullName ?? ""}
+            onChange={handleChange}
+            aria-invalid={!!fieldErrors.full_name}
+          />
+          {fieldErrors.full_name && <div className="cnf-form__message--error">{fieldErrors.full_name}</div>}
+        </div>
+
+        <div className="cnf-form__group">
+          <Checkbox
+            id="display_full_name"
+            name="display_full_name"
+            value="true"
+            defaultChecked={initialDisplayFullName}
+            label="Show my full name instead of my username"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset className="cnf-form__fieldset">
+        <legend>Change password</legend>
+
+        <div className="cnf-form__group">
+          <label className="cnf-form__label" htmlFor="current-password">Current password</label>
+          <input
+            id="current-password"
+            type="password"
+            name="current_password"
+            className="cnf-form__input"
+            autoComplete="current-password"
+            onChange={handleChange}
+            aria-invalid={!!fieldErrors.current_password}
+          />
+          <p className="cnf-form__hint">Leave these blank to keep your current password.</p>
+          {fieldErrors.current_password && <div className="cnf-form__message--error">{fieldErrors.current_password}</div>}
+        </div>
+
+        <div className="cnf-form__group">
+          <label className="cnf-form__label" htmlFor="new-password">New password</label>
+          <input
+            id="new-password"
+            type="password"
+            name="new_password"
+            className="cnf-form__input"
+            autoComplete="new-password"
+            onChange={handleChange}
+            aria-invalid={!!fieldErrors.new_password}
+          />
+          <p className="cnf-form__hint">At least 8 characters, with a number and an uppercase letter.</p>
+          {fieldErrors.new_password && <div className="cnf-form__message--error">{fieldErrors.new_password}</div>}
+        </div>
+
+        <div className="cnf-form__group">
+          <label className="cnf-form__label" htmlFor="confirm-new-password">Confirm new password</label>
+          <input
+            id="confirm-new-password"
+            type="password"
+            name="confirm_password"
+            className="cnf-form__input"
+            autoComplete="new-password"
+            onChange={handleChange}
+            aria-invalid={!!fieldErrors.confirm_password}
+          />
+          {fieldErrors.confirm_password && <div className="cnf-form__message--error">{fieldErrors.confirm_password}</div>}
+        </div>
+      </fieldset>
+
+      <button type="submit" disabled={status === "loading"} aria-busy={status === "loading"} className={`cnf-form__submit cnf-button cnf-button__gold${status === "loading" ? " cnf-button--loading" : ""}`}>
+        <span className="cnf-button__text">Save</span>
+      </button>
+    </form>
+  );
+}

--- a/src/components/AccountMenu/AccountMenu.tsx
+++ b/src/components/AccountMenu/AccountMenu.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import Dropdown from "../Dropdown/Dropdown";
+import { fetchSessionInfo } from "../../utils/session";
 
 interface AccountMenuProps {
   pathname: string;
@@ -10,9 +11,7 @@ export default function AccountMenu({ pathname }: AccountMenuProps) {
   const toggleRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    fetch("/api/me")
-      .then((r) => r.json())
-      .then((data) => setIsAdmin(!!data.isAdmin));
+    fetchSessionInfo().then((data) => setIsAdmin(!!data.isAdmin));
   }, []);
 
   return (

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Checkbox from "./Checkbox";
+
+describe("Checkbox", () => {
+  it("renders as a real checkbox associated with its label", () => {
+    render(<Checkbox id="opt-in" name="opt_in" label="Opt in" />);
+
+    const input = screen.getByLabelText("Opt in") as HTMLInputElement;
+    expect(input.type).toBe("checkbox");
+    expect(input.checked).toBe(false);
+  });
+
+  it("respects defaultChecked", () => {
+    render(<Checkbox id="opt-in" name="opt_in" label="Opt in" defaultChecked />);
+
+    expect(screen.getByLabelText("Opt in")).toBeChecked();
+  });
+
+  it("toggles when clicked, including via the label text", () => {
+    render(<Checkbox id="opt-in" name="opt_in" label="Opt in" />);
+
+    const input = screen.getByLabelText("Opt in");
+    fireEvent.click(screen.getByText("Opt in"));
+    expect(input).toBeChecked();
+
+    fireEvent.click(input);
+    expect(input).not.toBeChecked();
+  });
+
+  it("carries the given name and value for FormData-based submission", () => {
+    render(<Checkbox id="opt-in" name="opt_in" label="Opt in" value="true" defaultChecked />);
+
+    const input = screen.getByLabelText("Opt in") as HTMLInputElement;
+    expect(input.name).toBe("opt_in");
+    expect(input.value).toBe("true");
+  });
+
+  it("calls onChange when toggled", () => {
+    const onChange = vi.fn();
+    render(<Checkbox id="opt-in" name="opt_in" label="Opt in" onChange={onChange} />);
+
+    fireEvent.click(screen.getByLabelText("Opt in"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,34 @@
+import "../../styles/checkbox.css";
+
+interface CheckboxProps {
+  id: string;
+  name: string;
+  label: string;
+  value?: string;
+  defaultChecked?: boolean;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function Checkbox({ id, name, label, value, defaultChecked, onChange }: CheckboxProps) {
+  return (
+    <label className="cnf-checkbox" htmlFor={id}>
+      <span className="cnf-checkbox__control">
+        <input
+          id={id}
+          type="checkbox"
+          name={name}
+          value={value}
+          defaultChecked={defaultChecked}
+          onChange={onChange}
+          className="cnf-checkbox__input"
+        />
+        <span className="cnf-checkbox__box" aria-hidden="true">
+          <svg className="cnf-checkbox__check" viewBox="0 0 16 16" fill="none">
+            <path d="M3 8.5L6.5 12L13 4.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+      </span>
+      <span className="cnf-checkbox__label">{label}</span>
+    </label>
+  );
+}

--- a/src/components/LoginButton/LoginButton.tsx
+++ b/src/components/LoginButton/LoginButton.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import Modal from "../Modal/Modal";
 import LoginForm from "../LoginForm/LoginForm";
 import SignupForm from "../SignupForm/SignupForm";
+import { fetchSessionInfo, refreshSessionInfo } from "../../utils/session";
 
 type View = "login" | "signup";
 
@@ -27,7 +28,11 @@ export default function LoginButton() {
     const trigger = document.getElementById("cnf-login-trigger");
     trigger?.addEventListener("click", openModal);
 
-    reconcile();
+    applySessionInfo(fetchSessionInfo());
+
+    function reconcile() {
+      applySessionInfo(refreshSessionInfo());
+    }
     window.addEventListener("pageshow", reconcile);
 
     return () => {
@@ -36,13 +41,11 @@ export default function LoginButton() {
     };
   }, []);
 
-  function reconcile() {
-    fetch("/api/me")
-      .then((r) => r.json())
-      .then((data) => {
-        document.documentElement.classList.toggle("cnf-logged-in", data.loggedIn);
-        document.documentElement.classList.toggle("cnf-logged-out", !data.loggedIn);
-      });
+  function applySessionInfo(info: ReturnType<typeof fetchSessionInfo>) {
+    info.then((data) => {
+      document.documentElement.classList.toggle("cnf-logged-in", data.loggedIn);
+      document.documentElement.classList.toggle("cnf-logged-out", !data.loggedIn);
+    });
   }
 
   function handleSignupSuccess(email: string) {

--- a/src/components/SignupForm/SignupForm.tsx
+++ b/src/components/SignupForm/SignupForm.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { actions } from "astro:actions";
 import { validateUsername, validatePassword } from "../../utils/validation";
 import { isValidEmail } from "../../utils/script";
+import Checkbox from "../Checkbox/Checkbox";
 import "../../styles/form.css";
 
 interface SignupFormProps {
@@ -151,9 +152,8 @@ export default function SignupForm({ onSwitchToLogin, isAdmin = false }: SignupF
       </div>
 
       {isAdmin && (
-        <div className="cnf-form__group cnf-form__group--inline">
-          <input id="signup-is-admin" type="checkbox" name="is_admin" value="true" />
-          <label className="cnf-form__label" htmlFor="signup-is-admin">Admin</label>
+        <div className="cnf-form__group">
+          <Checkbox id="signup-is-admin" name="is_admin" value="true" label="Admin" />
         </div>
       )}
 

--- a/src/lib/memberDisplay.test.ts
+++ b/src/lib/memberDisplay.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { getDisplayName } from "./memberDisplay";
+
+describe("getDisplayName", () => {
+  it("returns the username when display_full_name is false", () => {
+    expect(getDisplayName({ username: "johndoe", full_name: "John Doe", display_full_name: false })).toBe("johndoe");
+  });
+
+  it("returns the full name when display_full_name is true and a full name is set", () => {
+    expect(getDisplayName({ username: "johndoe", full_name: "John Doe", display_full_name: true })).toBe("John Doe");
+  });
+
+  it("falls back to the username when display_full_name is true but full_name is null", () => {
+    expect(getDisplayName({ username: "johndoe", full_name: null, display_full_name: true })).toBe("johndoe");
+  });
+
+  it("falls back to the username when display_full_name is true but full_name is empty", () => {
+    expect(getDisplayName({ username: "johndoe", full_name: "", display_full_name: true })).toBe("johndoe");
+  });
+});

--- a/src/lib/memberDisplay.ts
+++ b/src/lib/memberDisplay.ts
@@ -1,0 +1,12 @@
+export interface DisplayableMember {
+  username: string;
+  full_name: string | null;
+  display_full_name: boolean;
+}
+
+export function getDisplayName(member: DisplayableMember): string {
+  if (member.display_full_name && member.full_name) {
+    return member.full_name;
+  }
+  return member.username;
+}

--- a/src/pages/admin/members.astro
+++ b/src/pages/admin/members.astro
@@ -4,7 +4,7 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
 import { supabaseAdmin } from "../../lib/supabase";
 
 const { data: members } = supabaseAdmin
-  ? await supabaseAdmin.from("members").select("id, username, email, is_admin, created_at").order("created_at", { ascending: false })
+  ? await supabaseAdmin.from("members").select("id, username, full_name, email, is_admin, created_at").order("created_at", { ascending: false })
   : { data: [] };
 ---
 
@@ -20,6 +20,7 @@ const { data: members } = supabaseAdmin
       <thead>
         <tr>
           <th>Username</th>
+          <th>Full name</th>
           <th>Email</th>
           <th>Role</th>
           <th>Created</th>
@@ -29,6 +30,7 @@ const { data: members } = supabaseAdmin
         {(members ?? []).map((member) => (
           <tr>
             <td data-label="Username">{member.username ?? "—"}</td>
+            <td data-label="Full name">{member.full_name ?? "—"}</td>
             <td data-label="Email">{member.email}</td>
             <td data-label="Role">{member.is_admin ? "Admin" : "Member"}</td>
             <td data-label="Created">{new Date(member.created_at).toLocaleDateString("en-IE", { day: "numeric", month: "short", year: "numeric" })}</td>

--- a/src/pages/profile/[username].astro
+++ b/src/pages/profile/[username].astro
@@ -1,29 +1,47 @@
 ---
 export const prerender = false;
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getSessionToken, verifySessionToken } from "../../lib/auth";
 import { supabaseAdmin } from "../../lib/supabase";
+import { getDisplayName } from "../../lib/memberDisplay";
 
 const { username } = Astro.params;
 
 const { data: profileUser } = supabaseAdmin
-  ? await supabaseAdmin.from("members").select("username, created_at").eq("username", username).single()
+  ? await supabaseAdmin.from("members").select("username, full_name, display_full_name, created_at").eq("username", username).single()
   : { data: null };
 
 if (!profileUser) {
   Astro.response.status = 404;
 }
 
+const displayName = profileUser ? getDisplayName(profileUser) : null;
+
 const memberSince = profileUser
   ? new Date(profileUser.created_at).toLocaleDateString("en-IE", { day: "numeric", month: "short", year: "numeric" })
   : null;
+
+const token = getSessionToken(Astro.request);
+const payload = token ? verifySessionToken(token) : null;
+
+let isOwnProfile = false;
+if (payload && profileUser) {
+  const { data: currentMember } = supabaseAdmin
+    ? await supabaseAdmin.from("members").select("username").eq("email", payload.email).single()
+    : { data: null };
+  isOwnProfile = currentMember?.username.toLowerCase() === profileUser.username.toLowerCase();
+}
 ---
 
-<BaseLayout pageTitle={profileUser ? profileUser.username : "Profile not found"}>
+<BaseLayout pageTitle={profileUser ? displayName : "Profile not found"}>
   <section class="cnf-section">
     {profileUser ? (
       <>
-        <h1>{profileUser.username}</h1>
+        <h1>{displayName}</h1>
         <p>Member since: {memberSince}</p>
+        {isOwnProfile && (
+          <p><a href="/profile/edit">Edit your info</a></p>
+        )}
       </>
     ) : (
       <>

--- a/src/pages/profile/edit.astro
+++ b/src/pages/profile/edit.astro
@@ -1,0 +1,37 @@
+---
+export const prerender = false;
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import AccountForm from "../../components/AccountForm/AccountForm";
+import { getSessionToken, verifySessionToken } from "../../lib/auth";
+import { supabaseAdmin } from "../../lib/supabase";
+
+const token = getSessionToken(Astro.request);
+const payload = token ? verifySessionToken(token) : null;
+
+if (!payload) {
+  return Astro.redirect("/");
+}
+
+const { data: member } = supabaseAdmin
+  ? await supabaseAdmin.from("members").select("username, email, full_name, display_full_name").eq("email", payload.email).single()
+  : { data: null };
+
+if (!member) {
+  return Astro.redirect("/");
+}
+---
+
+<BaseLayout pageTitle="Edit info">
+  <section class="cnf-section">
+    <div class="cnf-section__header">
+      <h1>Edit info</h1>
+      <a href="/profile">Back to profile</a>
+    </div>
+    <AccountForm
+      client:load
+      initialUsername={member.username}
+      initialFullName={member.full_name}
+      initialDisplayFullName={member.display_full_name}
+    />
+  </section>
+</BaseLayout>

--- a/src/pages/verify-email.astro
+++ b/src/pages/verify-email.astro
@@ -25,7 +25,7 @@ if (payload && supabaseAdmin) {
 <BaseLayout pageTitle={pageTitle}>
   <section class="cnf-section">
     <h1>{pageTitle}</h1>
-    {state === "success" && <p>Your email is confirmed — you can now log in.</p>}
+    {state === "success" && <p>Your email is confirmed, you can now log in.</p>}
     {state === "invalid" && <p>This confirmation link is invalid or has expired. Please contact an admin to get a new one.</p>}
     {state === "error" && <p>Something went wrong confirming your email. Please try again later.</p>}
     <p><a href="/">Back to homepage</a></p>

--- a/src/styles/checkbox.css
+++ b/src/styles/checkbox.css
@@ -1,0 +1,69 @@
+.cnf-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+}
+
+.cnf-checkbox__control {
+  position: relative;
+  display: inline-flex;
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+}
+
+/* Real checkbox stays in place and in the a11y tree - it's just made invisible
+   (not display:none) so keyboard focus, click target and FormData reads all
+   keep working exactly as a native checkbox. The box below is purely visual. */
+.cnf-checkbox__input {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.cnf-checkbox__box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background-color: hsl(var(--color-white));
+  border: 2px solid hsl(var(--color-green));
+  /* Scaled down from the site's card/button radius token - at full size it'd
+     round this small a box into a circle rather than a rounded square. */
+  border-radius: calc(var(--border-radius) * 0.3);
+  color: hsl(var(--color-white));
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.cnf-checkbox__check {
+  width: 70%;
+  height: 70%;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.cnf-checkbox__input:checked + .cnf-checkbox__box {
+  background-color: hsl(var(--color-green));
+  border-color: hsl(var(--color-green));
+}
+
+.cnf-checkbox__input:checked + .cnf-checkbox__box .cnf-checkbox__check {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* Opacity:0 on the input hides its own outline too, so the focus ring is
+   drawn on the visible box instead via the sibling selector. */
+.cnf-checkbox__input:focus-visible + .cnf-checkbox__box {
+  outline: 2px solid hsl(var(--color-green));
+  outline-offset: 2px;
+}
+
+.cnf-checkbox__label {
+  font-size: 1.125rem;
+}

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -3,6 +3,39 @@
   gap: 1rem;
 }
 
+fieldset {
+  border: none;
+  margin: 0 0 1.5rem 0;
+  padding: 0;
+  min-width: 0;
+}
+
+.cnf-form__fieldset {
+  display: grid;
+  gap: 1rem;
+}
+
+legend {
+  padding: 0;
+  margin: 0 0 1rem 0;
+  color: hsl(var(--color-green));
+  font-family: "Playfair Display", serif;
+  font-size: 1.5em;
+  font-weight: bold;
+}
+
+.cnf-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .cnf-form__group {
   display: flex;
   flex-direction: column;
@@ -81,12 +114,6 @@ select.cnf-form__input {
   width: 1px;
   height: 1px;
   overflow: hidden;
-}
-
-.cnf-form__group--inline {
-  flex-direction: row;
-  align-items: center;
-  gap: 0.75rem;
 }
 
 .cnf-form__message--error:empty {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -71,6 +71,8 @@ select {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
 }
 
 .cnf-section--narrow {

--- a/src/utils/session.test.ts
+++ b/src/utils/session.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+async function importFresh() {
+  vi.resetModules();
+  return import("./session.ts");
+}
+
+describe("fetchSessionInfo / refreshSessionInfo", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ loggedIn: true, isAdmin: false }) }))
+    );
+  });
+
+  it("coalesces concurrent calls into a single request", async () => {
+    const { fetchSessionInfo } = await importFresh();
+
+    const [a, b] = await Promise.all([fetchSessionInfo(), fetchSessionInfo()]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(a).toEqual({ loggedIn: true, isAdmin: false });
+    expect(b).toEqual({ loggedIn: true, isAdmin: false });
+  });
+
+  it("reuses the cached result for later calls, even after the first resolves", async () => {
+    const { fetchSessionInfo } = await importFresh();
+
+    await fetchSessionInfo();
+    await fetchSessionInfo();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshSessionInfo always issues a fresh request", async () => {
+    const { fetchSessionInfo, refreshSessionInfo } = await importFresh();
+
+    await fetchSessionInfo();
+    await refreshSessionInfo();
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("fetchSessionInfo after a refresh reuses the refreshed value", async () => {
+    const { fetchSessionInfo, refreshSessionInfo } = await importFresh();
+
+    await refreshSessionInfo();
+    await fetchSessionInfo();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,29 @@
+export interface SessionInfo {
+  loggedIn: boolean;
+  isAdmin: boolean;
+}
+
+let current: Promise<SessionInfo> | null = null;
+
+function request(): Promise<SessionInfo> {
+  current = fetch("/api/me").then((r) => r.json());
+  return current;
+}
+
+// Multiple islands (AccountMenu, LoginButton) each need session info on mount.
+// This is a full MPA (no client-side routing), so the session can't change
+// mid-page except via an explicit action (login reloads the page, logout is
+// a form POST) - caching for the page's lifetime means whichever island
+// mounts first fetches, and the rest reuse that same result instead of each
+// issuing their own /api/me request.
+export function fetchSessionInfo(): Promise<SessionInfo> {
+  return current ?? request();
+}
+
+// Forces a fresh /api/me check, bypassing the cache. Used by LoginButton's
+// pageshow handler to catch a session that was revoked while the page sat
+// in the back/forward cache - a case fetchSessionInfo's page-lifetime cache
+// would otherwise miss.
+export function refreshSessionInfo(): Promise<SessionInfo> {
+  return request();
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -7,6 +7,13 @@ export function validateUsername(username: string): string | null {
   return null;
 }
 
+export function validateFullName(fullName: string): string | null {
+  if (fullName.length > 100) {
+    return "Full name must be 100 characters or fewer";
+  }
+  return null;
+}
+
 export function validatePassword(password: string): string | null {
   if (password.length < 8) return "Password must be at least 8 characters";
   if (!/[0-9]/.test(password)) return "Password must contain at least one number";

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,6 +1,8 @@
 CREATE TABLE members (
   id                UUID DEFAULT gen_random_uuid() PRIMARY KEY,
   username          TEXT NOT NULL,
+  full_name         TEXT,
+  display_full_name BOOLEAN DEFAULT FALSE NOT NULL,
   email             TEXT UNIQUE NOT NULL,
   password_hash     TEXT NOT NULL,
   is_admin          BOOLEAN DEFAULT FALSE NOT NULL,


### PR DESCRIPTION
## Summary

Lets members edit their own profile from a dedicated `/profile/edit` page, linked from the account menu.

- Members can change their username (with the same validation as signup).
- Members can set an optional full name and choose whether it's shown publicly instead of their username, via `getDisplayName()` (`src/lib/memberDisplay.ts`). Admins always see full names regardless of that preference.
- Username, full name/display preference, and password change are all one merged `AccountForm` with a single "Save" button (previously the plan was two separate forms/buttons, but that meant two gold CTAs competing on one page). Filling in the *new* password field (not "current password", which password managers autofill on page load) is what signals intent to change the password — leaving the password fields blank saves just the profile info. Submitting fires `updateUsername` and (if intended) `changePassword` in parallel, with explicit messaging for every partial-success/failure combination.
- The profile-details and password fields are grouped in real `<fieldset>`/`<legend>` pairs, not just visually-separated `<div>`s — proper semantic grouping for assistive tech.
- New reusable `Checkbox` component: a real `<input type="checkbox">`, visually hidden and overlaid on a custom-styled box (green fill + checkmark on check), wrapped in one `<label>`. Keyboard/screen-reader behavior and `FormData`-based submission both work exactly as a native checkbox would. Replaces the two raw checkboxes that existed before (`display_full_name` here, `is_admin` in the member-creation form).

## Testing

- `npx vitest run`: 101/101 passing (new `AccountForm.test.tsx` and `Checkbox.test.tsx`, existing suites unaffected).
- `npx astro check`: 0 errors (1 pre-existing unrelated warning in `AdminLayout.astro`).
- `npx astro build`: succeeds.