### PR TITLE
Include member id in session token

### DIFF
--- a/src/actions/changePassword.ts
+++ b/src/actions/changePassword.ts
@@ -36,7 +36,7 @@ export const changePassword = defineAction({
     const { data: member } = await supabaseAdmin
       .from('members')
       .select('password_hash')
-      .eq('email', payload.email)
+      .eq('id', payload.memberId)
       .single();
 
     if (!member) {
@@ -53,7 +53,7 @@ export const changePassword = defineAction({
     const { error } = await supabaseAdmin
       .from('members')
       .update({ password_hash })
-      .eq('email', payload.email);
+      .eq('id', payload.memberId);
 
     if (error) {
       throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to update password' });

--- a/src/actions/events.ts
+++ b/src/actions/events.ts
@@ -1,14 +1,12 @@
 import { defineAction, ActionError } from 'astro:actions';
 import { supabase, supabaseAdmin } from '../lib/supabase';
 import { sendMailchimpEmail } from '../lib/mailchimp';
-import { verifySessionToken } from '../lib/auth';
+import { requireAdmin } from '../lib/auth';
 
 export const createEvent = defineAction({
   accept: 'form',
   handler: async (formData, context) => {
-    const token = context.cookies.get('session')?.value;
-    const payload = token ? verifySessionToken(token) : null;
-    if (!payload) {
+    if (!(await requireAdmin(context.request))) {
       throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
     }
 
@@ -91,9 +89,7 @@ export const createEvent = defineAction({
 export const updateEvent = defineAction({
   accept: 'form',
   handler: async (formData, context) => {
-    const token = context.cookies.get('session')?.value;
-    const payload = token ? verifySessionToken(token) : null;
-    if (!payload) {
+    if (!(await requireAdmin(context.request))) {
       throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
     }
 
@@ -176,9 +172,7 @@ export const getLocations = defineAction({
 
 export const getVenues = defineAction({
   handler: async (_, context) => {
-    const token = context.cookies.get('session')?.value;
-    const payload = token ? verifySessionToken(token) : null;
-    if (!payload) {
+    if (!(await requireAdmin(context.request))) {
       throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
     }
 

--- a/src/actions/members.ts
+++ b/src/actions/members.ts
@@ -1,13 +1,11 @@
 import { defineAction, ActionError } from 'astro:actions';
-import { verifySessionToken } from '../lib/auth';
+import { requireAdmin } from '../lib/auth';
 import { createAccount } from '../lib/memberAccount';
 
 export const createMember = defineAction({
   accept: 'form',
   handler: async (formData, context) => {
-    const token = context.cookies.get('session')?.value;
-    const payload = token ? verifySessionToken(token) : null;
-    if (!payload?.isAdmin) {
+    if (!(await requireAdmin(context.request))) {
       throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
     }
 

--- a/src/actions/posts.ts
+++ b/src/actions/posts.ts
@@ -1,14 +1,12 @@
 import { defineAction, ActionError } from 'astro:actions';
 import { supabaseAdmin } from '../lib/supabase';
 import { sendMailchimpPostEmail } from '../lib/mailchimp';
-import { verifySessionToken } from '../lib/auth';
+import { requireAdmin } from '../lib/auth';
 
 export const createPost = defineAction({
   accept: 'form',
   handler: async (formData, context) => {
-    const token = context.cookies.get('session')?.value;
-    const payload = token ? verifySessionToken(token) : null;
-    if (!payload) {
+    if (!(await requireAdmin(context.request))) {
       throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
     }
 
@@ -59,9 +57,7 @@ export const createPost = defineAction({
 export const updatePost = defineAction({
   accept: 'form',
   handler: async (formData, context) => {
-    const token = context.cookies.get('session')?.value;
-    const payload = token ? verifySessionToken(token) : null;
-    if (!payload) {
+    if (!(await requireAdmin(context.request))) {
       throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
     }
 

--- a/src/actions/updateUsername.ts
+++ b/src/actions/updateUsername.ts
@@ -39,7 +39,7 @@ export const updateUsername = defineAction({
       .from('members')
       .select('id')
       .ilike('username', escapeLikePattern(username))
-      .neq('email', payload.email)
+      .neq('id', payload.memberId)
       .single();
 
     if (existingUsername) {
@@ -49,7 +49,7 @@ export const updateUsername = defineAction({
     const { error } = await supabaseAdmin
       .from('members')
       .update({ username, full_name: fullName || null, display_full_name: displayFullName })
-      .eq('email', payload.email);
+      .eq('id', payload.memberId);
 
     if (error) {
       throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to update info' });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { randomBytes, scrypt, timingSafeEqual } from "crypto";
 import { promisify } from "util";
 import jwt from "jsonwebtoken";
+import { supabaseAdmin } from "./supabase";
 
 const scryptAsync = promisify(scrypt);
 
@@ -23,10 +24,10 @@ export async function verifyPassword(password: string, stored: string): Promise<
   return hash.length === storedBuffer.length && timingSafeEqual(hash, storedBuffer);
 }
 
-export function createSessionToken(email: string, isAdmin: boolean): string {
+export function createSessionToken(memberId: string, isAdmin: boolean): string {
   const secret = process.env.JWT_SECRET;
   if (!secret) throw new Error("JWT_SECRET is not set");
-  return jwt.sign({ email, isAdmin }, secret, { expiresIn: SESSION_DURATION_STR });
+  return jwt.sign({ memberId, isAdmin }, secret, { expiresIn: SESSION_DURATION_STR });
 }
 
 const VERIFICATION_TOKEN_DURATION = "3d";
@@ -55,15 +56,44 @@ export function getSessionToken(request: Request): string | undefined {
   return cookie.match(/(?:^|;\s*)session=([^;]+)/)?.[1];
 }
 
-export function verifySessionToken(token: string): { email: string; isAdmin: boolean } | null {
+export function verifySessionToken(token: string): { memberId: string; isAdmin: boolean } | null {
   const secret = process.env.JWT_SECRET;
   if (!secret) return null;
   try {
-    const payload = jwt.verify(token, secret) as { email: string; isAdmin: boolean };
-    return payload;
+    const payload = jwt.verify(token, secret) as { memberId?: string; isAdmin: boolean };
+    // Pre-rollout session tokens carried `email` instead of `memberId`. JWT_SECRET
+    // doesn't rotate on deploy, so a cookie issued before this shipped still
+    // verifies but decodes with no memberId - treat that as invalid so the user
+    // gets a clean re-login instead of scattered "not authenticated" failures.
+    if (!payload.memberId) return null;
+    return payload as { memberId: string; isAdmin: boolean };
   } catch {
     return null;
   }
+}
+
+// The token's own isAdmin claim is fine for cosmetic reads (e.g. showing/hiding
+// a nav link) but anything that actually GATES access should call this instead:
+// it checks the members table live, so revoking admin rights takes effect on
+// the very next request instead of waiting out the token's 30-day expiry.
+// Fails closed - a missing Supabase client, a query error, or no matching row
+// (payload.memberId always comes from a verified token, but data can still be
+// deleted or misconfigured) all resolve to "not admin".
+export async function isMemberAdmin(memberId: string): Promise<boolean> {
+  if (!supabaseAdmin) return false;
+  const { data } = await supabaseAdmin.from("members").select("is_admin").eq("id", memberId).single();
+  return !!data?.is_admin;
+}
+
+// Single admin-gate check shared by middleware and every admin-only action.
+// Extracts and verifies the session cookie, then confirms admin status live
+// via isMemberAdmin. Returns the payload when authorized, null otherwise -
+// callers decide how to respond (redirect vs. throw ActionError).
+export async function requireAdmin(request: Request): Promise<{ memberId: string; isAdmin: boolean } | null> {
+  const token = getSessionToken(request);
+  const payload = token ? verifySessionToken(token) : null;
+  if (!payload || !(await isMemberAdmin(payload.memberId))) return null;
+  return payload;
 }
 
 // Safari (unlike Chrome) refuses to store cookies marked Secure over plain HTTP,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
 import { defineMiddleware } from "astro:middleware";
-import { getSessionToken, verifySessionToken } from "./lib/auth";
+import { requireAdmin } from "./lib/auth";
 import { isTrustedOrigin } from "./lib/csrf";
 
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
@@ -13,12 +13,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     return next();
   }
 
-  const token = getSessionToken(context.request);
-
-  if (token) {
-    const payload = verifySessionToken(token);
-    if (payload?.isAdmin) return next();
-  }
+  if (await requireAdmin(context.request)) return next();
 
   return context.redirect("/login");
 });

--- a/src/pages/api/login.ts
+++ b/src/pages/api/login.ts
@@ -26,7 +26,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   const { data: byEmail } = await supabaseAdmin
     .from("members")
-    .select("email, password_hash, is_admin, email_verified_at")
+    .select("id, email, password_hash, is_admin, email_verified_at")
     .eq("email", identifier.toLowerCase())
     .single();
 
@@ -35,7 +35,7 @@ export const POST: APIRoute = async ({ request }) => {
     (
       await supabaseAdmin
         .from("members")
-        .select("email, password_hash, is_admin, email_verified_at")
+        .select("id, email, password_hash, is_admin, email_verified_at")
         .ilike("username", escapeLikePattern(identifier))
         .single()
     ).data;
@@ -53,7 +53,7 @@ export const POST: APIRoute = async ({ request }) => {
     return json({ error: "Please confirm your email before logging in — check your inbox for the confirmation link." }, 403);
   }
 
-  const token = createSessionToken(user.email, user.is_admin);
+  const token = createSessionToken(user.id, user.is_admin);
   const maxAge = Math.floor(SESSION_DURATION_MS / 1000);
   const cookie = `session=${token}; HttpOnly; ${SECURE_COOKIE}SameSite=Strict; Path=/; Max-Age=${maxAge}`;
 

--- a/src/pages/api/me.ts
+++ b/src/pages/api/me.ts
@@ -15,5 +15,9 @@ export const GET: APIRoute = ({ request }) => {
   // instead of flashing the wrong logged-in state on every future page load.
   headers.append("Set-Cookie", payload ? loggedInHintCookie() : clearedLoggedInHintCookie());
 
+  // isAdmin here is straight from the token, not a live lookup — it only drives
+  // showing/hiding the "Admin console" link, and middleware re-checks live before
+  // actually granting access, so a stale claim here is at most a dead link, never
+  // a privilege leak. See middleware.ts / createMember for the live-checked gates.
   return new Response(JSON.stringify({ loggedIn: !!payload, isAdmin: !!payload?.isAdmin }), { headers });
 };

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -11,7 +11,7 @@ if (!payload) {
 }
 
 const { data: user } = supabaseAdmin
-  ? await supabaseAdmin.from("members").select("username").eq("email", payload.email).single()
+  ? await supabaseAdmin.from("members").select("username").eq("id", payload.memberId).single()
   : { data: null };
 
 if (!user?.username) {

--- a/src/pages/profile/[username].astro
+++ b/src/pages/profile/[username].astro
@@ -27,7 +27,7 @@ const payload = token ? verifySessionToken(token) : null;
 let isOwnProfile = false;
 if (payload && profileUser) {
   const { data: currentMember } = supabaseAdmin
-    ? await supabaseAdmin.from("members").select("username").eq("email", payload.email).single()
+    ? await supabaseAdmin.from("members").select("username").eq("id", payload.memberId).single()
     : { data: null };
   isOwnProfile = currentMember?.username.toLowerCase() === profileUser.username.toLowerCase();
 }

--- a/src/pages/profile/edit.astro
+++ b/src/pages/profile/edit.astro
@@ -13,7 +13,7 @@ if (!payload) {
 }
 
 const { data: member } = supabaseAdmin
-  ? await supabaseAdmin.from("members").select("username, email, full_name, display_full_name").eq("email", payload.email).single()
+  ? await supabaseAdmin.from("members").select("username, email, full_name, display_full_name").eq("id", payload.memberId).single()
   : { data: null };
 
 if (!member) {

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,414 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "clubnafealsunachta"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. When unset, new entities are NOT auto-exposed, matching the new cloud
+# default. Set to `true` to keep the legacy behaviour of auto-exposing new entities; this is
+# deprecated and the field is removed on 2026-10-30 once the always-revoked behaviour is permanent.
+# auto_expose_new_tables = true
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files, directories, or glob patterns that describe your database.
+# Supports paths relative to supabase directory: "./schemas/*.sql", "./database".
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[local_smtp]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# pg-delta is the schema diff engine for db diff / db pull / db remote commit.
+# Set enabled = false to fall back to the legacy migra engine.
+[experimental.pgdelta]
+enabled = true
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260817135719_remote_schema.sql
+++ b/supabase/migrations/20260817135719_remote_schema.sql
@@ -1,0 +1,235 @@
+-- Migration unit 1: schema_changes
+-- Transaction mode: transactional
+-- Boundary reason: default
+
+SET check_function_bodies = false;
+
+DROP EXTENSION pg_graphql;
+
+CREATE EXTENSION pg_cron WITH SCHEMA pg_catalog;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT DELETE, INSERT, SELECT, UPDATE ON TABLES TO anon;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT SELECT, USAGE ON SEQUENCES TO anon;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON ROUTINES TO anon;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT DELETE, INSERT, SELECT, UPDATE ON TABLES TO authenticated;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT SELECT, USAGE ON SEQUENCES TO authenticated;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON ROUTINES TO authenticated;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT DELETE, INSERT, SELECT, UPDATE ON TABLES TO service_role;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT SELECT, USAGE ON SEQUENCES TO service_role;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON ROUTINES TO service_role;
+
+CREATE SEQUENCE public.events_id_seq AS integer;
+
+CREATE SEQUENCE public.locations_id_seq AS integer;
+
+CREATE SEQUENCE public.posts_id_seq AS integer;
+
+CREATE SEQUENCE public.venues_id_seq AS integer;
+
+CREATE FUNCTION public.delete_stale_unverified_members()
+  RETURNS void
+  LANGUAGE sql
+  AS $function$
+  DELETE FROM members
+  WHERE email_verified_at IS NULL
+    AND created_at < NOW() - INTERVAL '30 days';
+$function$;
+
+GRANT ALL ON FUNCTION public.delete_stale_unverified_members() TO anon;
+
+GRANT ALL ON FUNCTION public.delete_stale_unverified_members() TO authenticated;
+
+GRANT ALL ON FUNCTION public.delete_stale_unverified_members() TO service_role;
+
+CREATE TABLE public.events (
+  id          integer                  DEFAULT nextval('public.events_id_seq'::regclass) NOT NULL,
+  name        text                     NOT NULL,
+  date        timestamp with time zone NOT NULL,
+  slug        text                     NOT NULL,
+  instagram   text,
+  facebook    text,
+  meetup      text,
+  description text,
+  summary     text,
+  created_at  timestamp with time zone DEFAULT now(),
+  venue_id    integer,
+  location_id integer,
+  meeting_url text
+);
+
+ALTER SEQUENCE public.events_id_seq OWNED BY public.events.id;
+
+GRANT ALL ON SEQUENCE public.events_id_seq TO anon;
+
+GRANT ALL ON SEQUENCE public.events_id_seq TO authenticated;
+
+GRANT ALL ON SEQUENCE public.events_id_seq TO service_role;
+
+ALTER TABLE public.events
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.events
+  ADD CONSTRAINT events_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.events
+  ADD CONSTRAINT events_slug_key UNIQUE (slug);
+
+GRANT ALL ON public.events TO anon;
+
+GRANT ALL ON public.events TO authenticated;
+
+GRANT ALL ON public.events TO service_role;
+
+CREATE TRIGGER "rebuild-on-event-change"
+  AFTER INSERT OR DELETE OR UPDATE ON public.events
+  FOR EACH ROW
+  EXECUTE FUNCTION supabase_functions.http_request('https://api.netlify.com/build_hooks/69ef16eb933e0dd40db64ab7', 'POST', '{"Content-type":"application/json"}', '{}', '5000');
+
+CREATE POLICY "public read events" ON public.events
+  FOR SELECT
+  USING (true);
+
+CREATE TABLE public.locations (
+  id   integer DEFAULT nextval('public.locations_id_seq'::regclass) NOT NULL,
+  name text    NOT NULL
+);
+
+ALTER SEQUENCE public.locations_id_seq OWNED BY public.locations.id;
+
+GRANT ALL ON SEQUENCE public.locations_id_seq TO anon;
+
+GRANT ALL ON SEQUENCE public.locations_id_seq TO authenticated;
+
+GRANT ALL ON SEQUENCE public.locations_id_seq TO service_role;
+
+ALTER TABLE public.locations
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.locations
+  ADD CONSTRAINT locations_name_key UNIQUE (name);
+
+ALTER TABLE public.locations
+  ADD CONSTRAINT locations_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.events
+  ADD CONSTRAINT events_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.locations(id);
+
+GRANT ALL ON public.locations TO anon;
+
+GRANT ALL ON public.locations TO authenticated;
+
+GRANT ALL ON public.locations TO service_role;
+
+CREATE POLICY "Enable read access for all users" ON public.locations
+  FOR SELECT
+  USING (true);
+
+CREATE TABLE public.members (
+  id                uuid                     DEFAULT gen_random_uuid() NOT NULL,
+  email             text                     NOT NULL,
+  password_hash     text                     NOT NULL,
+  created_at        timestamp with time zone DEFAULT now(),
+  is_admin          boolean                  DEFAULT false NOT NULL,
+  username          text                     NOT NULL,
+  email_verified_at timestamp with time zone,
+  full_name         text,
+  display_full_name boolean                  DEFAULT false NOT NULL
+);
+
+ALTER TABLE public.members
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.members
+  ADD CONSTRAINT members_email_key UNIQUE (email);
+
+ALTER TABLE public.members
+  ADD CONSTRAINT members_pkey PRIMARY KEY (id);
+
+GRANT ALL ON public.members TO anon;
+
+GRANT ALL ON public.members TO authenticated;
+
+GRANT ALL ON public.members TO service_role;
+
+CREATE UNIQUE INDEX members_username_lower_idx ON public.members (lower(username));
+
+CREATE TABLE public.posts (
+  id         integer                  DEFAULT nextval('public.posts_id_seq'::regclass) NOT NULL,
+  title      text                     NOT NULL,
+  slug       text                     NOT NULL,
+  author     text                     NOT NULL,
+  date       timestamp with time zone NOT NULL,
+  body       text                     NOT NULL,
+  created_at timestamp with time zone DEFAULT now()
+);
+
+ALTER SEQUENCE public.posts_id_seq OWNED BY public.posts.id;
+
+GRANT ALL ON SEQUENCE public.posts_id_seq TO anon;
+
+GRANT ALL ON SEQUENCE public.posts_id_seq TO authenticated;
+
+GRANT ALL ON SEQUENCE public.posts_id_seq TO service_role;
+
+ALTER TABLE public.posts
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.posts
+  ADD CONSTRAINT posts_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.posts
+  ADD CONSTRAINT posts_slug_key UNIQUE (slug);
+
+GRANT ALL ON public.posts TO anon;
+
+GRANT ALL ON public.posts TO authenticated;
+
+GRANT ALL ON public.posts TO service_role;
+
+CREATE TABLE public.venues (
+  id          integer DEFAULT nextval('public.venues_id_seq'::regclass) NOT NULL,
+  name        text    NOT NULL,
+  url         text,
+  location_id integer NOT NULL
+);
+
+ALTER SEQUENCE public.venues_id_seq OWNED BY public.venues.id;
+
+GRANT ALL ON SEQUENCE public.venues_id_seq TO anon;
+
+GRANT ALL ON SEQUENCE public.venues_id_seq TO authenticated;
+
+GRANT ALL ON SEQUENCE public.venues_id_seq TO service_role;
+
+ALTER TABLE public.venues
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.venues
+  ADD CONSTRAINT venues_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.locations(id);
+
+ALTER TABLE public.venues
+  ADD CONSTRAINT venues_name_location_id_key UNIQUE (name, location_id);
+
+ALTER TABLE public.venues
+  ADD CONSTRAINT venues_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.events
+  ADD CONSTRAINT events_venue_id_fkey FOREIGN KEY (venue_id) REFERENCES public.venues(id);
+
+GRANT ALL ON public.venues TO anon;
+
+GRANT ALL ON public.venues TO authenticated;
+
+GRANT ALL ON public.venues TO service_role;
+
+CREATE POLICY "public read venues" ON public.venues
+  FOR SELECT
+  USING (true);


### PR DESCRIPTION
Closes #41. Closes #43.

Session JWT now carries `memberId` alongside `isAdmin` (`email` dropped — nothing read it). Every place that resolved "the current member" via a `members` lookup by email now looks up by `id` from the token instead: `updateUsername`, `changePassword`, `profile.astro`, `profile/[username].astro`, `profile/edit.astro`.

`isAdmin` stays in the token for cheap, non-gating reads (account menu's admin-link visibility, `profile.astro`'s redirect) — worst case a stale link, never a privilege leak. The places that actually gate something on admin status — `middleware.ts` (`/admin/*`), `createMember`, and (added after review) `createPost`/`updatePost`/`createEvent`/`updateEvent`/`getVenues` — all ignore the token's claim and call a shared `isMemberAdmin()` helper (`src/lib/auth.ts`) that looks `is_admin` up live by `memberId`, so revoking admin rights takes effect on the next request rather than waiting out the token's 30-day expiry.

**#43** was found reviewing this PR: the five post/event actions only checked that *someone* was logged in, never that they were an admin — Astro Actions are their own endpoints, so they never went through `middleware.ts`'s `/admin` path-prefix gate the way the console pages that render their forms do. Any member could create/edit posts and events by calling the action directly. Fixed in the same branch since it directly extends the `isMemberAdmin` pattern this PR introduced.

Also includes the Supabase CLI migrations scaffolding (baseline snapshot of the live schema, no schema change) set up earlier in the same session.

Blocks #29.