### PR TITLE
Link post authors and event creators to members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ pnpm-debug.log*
 # opencode configuration
 .opencode/
 opencode.json
+
+# Claude Code configuration
+.claude/

--- a/src/actions/events.ts
+++ b/src/actions/events.ts
@@ -2,11 +2,13 @@ import { defineAction, ActionError } from 'astro:actions';
 import { supabase, supabaseAdmin } from '../lib/supabase';
 import { sendMailchimpEmail } from '../lib/mailchimp';
 import { requireAdmin } from '../lib/auth';
+import { triggerNetlifyBuild } from '../lib/netlifyBuildHook';
 
 export const createEvent = defineAction({
   accept: 'form',
   handler: async (formData, context) => {
-    if (!(await requireAdmin(context.request))) {
+    const admin = await requireAdmin(context.request);
+    if (!admin) {
       throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
     }
 
@@ -52,6 +54,7 @@ export const createEvent = defineAction({
         slug,
         location_id,
         venue_id,
+        created_by: admin.memberId,
         meeting_url,
         instagram: (formData.get('instagram') as string) || null,
         facebook: (formData.get('facebook') as string) || null,
@@ -66,12 +69,7 @@ export const createEvent = defineAction({
       throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
     }
 
-    const buildHookUrl = process.env.NETLIFY_BUILD_HOOK_URL;
-    if (buildHookUrl) {
-      await fetch(buildHookUrl, { method: 'POST' }).catch((e) =>
-        console.error('Netlify build hook failed:', e)
-      );
-    }
+    triggerNetlifyBuild();
 
     await sendMailchimpEmail({
       name,
@@ -143,12 +141,7 @@ export const updateEvent = defineAction({
       throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
     }
 
-    const buildHookUrl = process.env.NETLIFY_BUILD_HOOK_URL;
-    if (buildHookUrl) {
-      await fetch(buildHookUrl, { method: 'POST' }).catch((e) =>
-        console.error('Netlify build hook failed:', e)
-      );
-    }
+    triggerNetlifyBuild();
 
     return { success: true };
   }

--- a/src/actions/posts.ts
+++ b/src/actions/posts.ts
@@ -2,11 +2,13 @@ import { defineAction, ActionError } from 'astro:actions';
 import { supabaseAdmin } from '../lib/supabase';
 import { sendMailchimpPostEmail } from '../lib/mailchimp';
 import { requireAdmin } from '../lib/auth';
+import { triggerNetlifyBuild } from '../lib/netlifyBuildHook';
 
 export const createPost = defineAction({
   accept: 'form',
   handler: async (formData, context) => {
-    if (!(await requireAdmin(context.request))) {
+    const admin = await requireAdmin(context.request);
+    if (!admin) {
       throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
     }
 
@@ -16,11 +18,10 @@ export const createPost = defineAction({
 
     const title = formData.get('title') as string;
     const slug = formData.get('slug') as string;
-    const author = formData.get('author') as string;
     const date = formData.get('date') as string;
     const body = formData.get('body') as string;
 
-    if (!title || !slug || !author || !date || !body) {
+    if (!title || !slug || !date || !body) {
       throw new ActionError({ code: 'BAD_REQUEST', message: 'Missing required fields' });
     }
 
@@ -30,7 +31,7 @@ export const createPost = defineAction({
 
     const { error } = await supabaseAdmin
       .from('posts')
-      .insert([{ title, slug, author, date, body }]);
+      .insert([{ title, slug, author_id: admin.memberId, date, body }]);
 
     if (error) {
       if (error.code === '23505') {
@@ -39,12 +40,7 @@ export const createPost = defineAction({
       throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
     }
 
-    const buildHookUrl = process.env.NETLIFY_BUILD_HOOK_URL;
-    if (buildHookUrl) {
-      await fetch(buildHookUrl, { method: 'POST' }).catch((e) =>
-        console.error('Netlify build hook failed:', e)
-      );
-    }
+    triggerNetlifyBuild();
 
     await sendMailchimpPostEmail({ title, slug, body }).catch((e) =>
       console.error('Mailchimp post email failed:', e)
@@ -67,17 +63,16 @@ export const updatePost = defineAction({
 
     const slug = formData.get('slug') as string;
     const title = formData.get('title') as string;
-    const author = formData.get('author') as string;
     const date = formData.get('date') as string;
     const body = formData.get('body') as string;
 
-    if (!title || !slug || !author || !date || !body) {
+    if (!title || !slug || !date || !body) {
       throw new ActionError({ code: 'BAD_REQUEST', message: 'Missing required fields' });
     }
 
     const { data: updated, error } = await supabaseAdmin
       .from('posts')
-      .update({ title, author, date, body })
+      .update({ title, date, body })
       .eq('slug', slug)
       .select('slug')
       .single();
@@ -90,12 +85,7 @@ export const updatePost = defineAction({
       throw new ActionError({ code: 'NOT_FOUND', message: 'Post not found' });
     }
 
-    const buildHookUrl = process.env.NETLIFY_BUILD_HOOK_URL;
-    if (buildHookUrl) {
-      await fetch(buildHookUrl, { method: 'POST' }).catch((e) =>
-        console.error('Netlify build hook failed:', e)
-      );
-    }
+    triggerNetlifyBuild();
 
     return { success: true };
   }

--- a/src/actions/updateUsername.ts
+++ b/src/actions/updateUsername.ts
@@ -3,6 +3,7 @@ import { verifySessionToken } from '../lib/auth';
 import { validateUsername, validateFullName } from '../utils/validation';
 import { escapeLikePattern } from '../lib/username';
 import { supabaseAdmin } from '../lib/supabase';
+import { triggerNetlifyBuild } from '../lib/netlifyBuildHook';
 
 export const updateUsername = defineAction({
   accept: 'form',
@@ -54,6 +55,8 @@ export const updateUsername = defineAction({
     if (error) {
       throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to update info' });
     }
+
+    triggerNetlifyBuild();
 
     return { success: true, username, full_name: fullName || null, display_full_name: displayFullName };
   },

--- a/src/components/BlogEntry.astro
+++ b/src/components/BlogEntry.astro
@@ -1,0 +1,29 @@
+---
+import { formatBlogDate } from "../utils/script";
+const { url, post } = Astro.props;
+---
+
+<style>
+  .cnf-latest-blogs__post {
+    margin-bottom: 1.5rem;
+  }
+
+  .cnf-latest-blogs__post h3 {
+    margin: 0;
+    padding-bottom: 0.25rem;
+  }
+
+  .cnf-latest-blogs__date {
+    color: hsl(var(--color-grey));
+    font-size: 1rem;
+  }
+</style>
+
+<li class="cnf-latest-blogs__post">
+  <a href={url}>
+    <h3>{post.title}</h3>
+  </a>
+  <span class="cnf-latest-blogs__date">
+    {formatBlogDate(post.date)}
+  </span>
+</li>

--- a/src/components/LatestPost.astro
+++ b/src/components/LatestPost.astro
@@ -1,40 +1,17 @@
 ---
 import { getCollection } from "astro:content";
-import { formatBlogDate } from "../utils/script";
+import BlogEntry from "./BlogEntry.astro";
 const latestBlogEntries = (await getCollection("blog"))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
   .slice(0, 3);
 ---
-
-<style>
-  .cnf-latest-blogs__post {
-    margin-bottom: 1.5rem;
-  }
-
-  .cnf-latest-blogs__post h3 {
-    margin: 0;
-    padding-bottom: 0.25rem;
-  }
-
-  .cnf-latest-blogs__date {
-    color: hsl(var(--color-grey));
-    font-size: 1rem;
-  }
-</style>
 
 <section class="cnf-section">
   <h2>Latest blog posts</h2>
   <ul class="cnf-latest-blogs">
     {
       latestBlogEntries.map((post) => (
-        <li class="cnf-latest-blogs__post">
-          <a href={`/posts/${post.id}`}>
-            <h3>{post.data.title}</h3>
-          </a>
-          <span class="cnf-latest-blogs__date">
-            {formatBlogDate(post.data.date)}
-          </span>
-        </li>
+        <BlogEntry url={`/posts/${post.id}`} post={post.data} />
       ))
     }
   </ul>

--- a/src/components/PostForm/PostForm.test.tsx
+++ b/src/components/PostForm/PostForm.test.tsx
@@ -16,7 +16,6 @@ vi.mock("astro:actions", () => ({
 const sampleInitialData = {
   title: "Test Post",
   slug: "test-post",
-  author: "Francis Quinn",
   date: "2026-01-01",
   body: "This is the body of the post.",
 };
@@ -30,7 +29,6 @@ describe("PostForm (create mode)", () => {
     render(<PostForm mode="create" />);
     expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/url slug/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/author/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/date/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/body/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^create$/i })).toBeInTheDocument();
@@ -84,7 +82,6 @@ describe("PostForm (edit mode)", () => {
   it("pre-populates all fields from initialData", () => {
     render(<PostForm mode="edit" initialData={sampleInitialData} />);
     expect(screen.getByLabelText(/title/i)).toHaveValue("Test Post");
-    expect(screen.getByLabelText(/author/i)).toHaveValue("Francis Quinn");
     expect(screen.getByLabelText(/date/i)).toHaveValue("2026-01-01");
     expect(screen.getByLabelText(/body/i)).toHaveValue("This is the body of the post.");
   });

--- a/src/components/PostForm/PostForm.tsx
+++ b/src/components/PostForm/PostForm.tsx
@@ -4,7 +4,6 @@ import { actions } from "astro:actions";
 export type PostFormInitialData = {
   title: string;
   slug: string;
-  author: string;
   date: string;
   body: string;
 };
@@ -98,20 +97,6 @@ export default function PostForm({ mode, initialData }: PostFormProps) {
             <small className="cnf-form__hint">Slug cannot be changed after creation.</small>
           </>
         )}
-      </div>
-
-      <div className="cnf-form__group">
-        <label className="cnf-form__label" htmlFor="author">
-          Author *
-        </label>
-        <input
-          className="cnf-form__input"
-          type="text"
-          id="author"
-          name="author"
-          defaultValue={initialData?.author}
-          required
-        />
       </div>
 
       <div className="cnf-form__group">

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -3,12 +3,18 @@ import { eventsLoader } from "./loaders/events";
 import { postsLoader } from "./loaders/posts";
 import 'dotenv/config';
 
+const memberRefSchema = z.object({
+  username: z.string(),
+  full_name: z.string().nullable(),
+  display_full_name: z.boolean(),
+});
+
 const blog = defineCollection({
   loader: postsLoader(),
   schema: z.object({
     title: z.string(),
     date: z.coerce.date(),
-    author: z.string(),
+    author: memberRefSchema,
   }),
 });
 
@@ -34,6 +40,7 @@ const event = defineCollection({
       meetup: z.string().nullable(),
     }),
     meetingUrl: z.string().nullable(),
+    creator: memberRefSchema,
   }),
 });
 

--- a/src/lib/netlifyBuildHook.ts
+++ b/src/lib/netlifyBuildHook.ts
@@ -1,0 +1,13 @@
+// Fires the Netlify build hook to trigger a rebuild after content that's
+// baked into static pages (posts, events, member display names) changes.
+// Deliberately fire-and-forget: callers should not await this on a
+// user-facing response path, since a slow/hanging build-hook endpoint has
+// nothing to do with whether the caller's own action succeeded.
+export function triggerNetlifyBuild(): void {
+  const buildHookUrl = process.env.NETLIFY_BUILD_HOOK_URL;
+  if (!buildHookUrl) return;
+
+  fetch(buildHookUrl, { method: 'POST' }).catch((e) =>
+    console.error('Netlify build hook failed:', e)
+  );
+}

--- a/src/lib/supabaseRelations.ts
+++ b/src/lib/supabaseRelations.ts
@@ -1,0 +1,10 @@
+// Supabase's embedded-relation typing returns either a single object or an
+// array depending on how it infers the FK's cardinality. This normalizes
+// either shape to a single row (or null), so callers don't each re-implement
+// the same ternary.
+export function unwrapRelation<T>(relation: T | T[] | null | undefined): T | null {
+  if (Array.isArray(relation)) {
+    return relation[0] ?? null;
+  }
+  return relation ?? null;
+}

--- a/src/loaders/events.ts
+++ b/src/loaders/events.ts
@@ -1,5 +1,6 @@
 import type { Loader } from 'astro/loaders';
 import { supabaseAdmin } from '../lib/supabase';
+import { unwrapRelation } from '../lib/supabaseRelations';
 
 export function eventsLoader(): Loader {
   return {
@@ -14,7 +15,7 @@ export function eventsLoader(): Loader {
       const [eventsResult, locationsResult] = await Promise.all([
         supabaseAdmin
           .from('events')
-          .select('*, venues(name, url)')
+          .select('*, venues(name, url), members(username, full_name, display_full_name)')
           .order('date', { ascending: true }),
         supabaseAdmin
           .from('locations')
@@ -32,8 +33,14 @@ export function eventsLoader(): Loader {
       const locationsMap = new Map(locationsResult.data?.map((l) => [l.id, l]) ?? []);
 
       for (const event of eventsResult.data || []) {
-        const venue = Array.isArray(event.venues) ? event.venues[0] ?? null : event.venues ?? null;
+        const venue = unwrapRelation(event.venues);
         const location = event.location_id ? locationsMap.get(event.location_id) ?? null : null;
+        const creator = unwrapRelation(event.members);
+
+        if (!creator) {
+          console.error(`Skipping event "${event.slug}": no matching member for created_by ${event.created_by}`);
+          continue;
+        }
 
         store.set({
           id: event.id.toString(),
@@ -51,6 +58,7 @@ export function eventsLoader(): Loader {
               meetup: event.meetup,
             },
             meetingUrl: event.meeting_url,
+            creator,
           },
         });
       }

--- a/src/loaders/posts.ts
+++ b/src/loaders/posts.ts
@@ -1,5 +1,6 @@
 import type { Loader } from 'astro/loaders';
 import { supabaseAdmin } from '../lib/supabase';
+import { unwrapRelation } from '../lib/supabaseRelations';
 
 export function postsLoader(): Loader {
   return {
@@ -13,7 +14,7 @@ export function postsLoader(): Loader {
 
       const { data, error } = await supabaseAdmin
         .from('posts')
-        .select('*')
+        .select('*, members(username, full_name, display_full_name)')
         .order('date', { ascending: false });
 
       if (error) {
@@ -21,13 +22,19 @@ export function postsLoader(): Loader {
       }
 
       for (const post of data || []) {
+        const author = unwrapRelation(post.members);
+        if (!author) {
+          console.error(`Skipping post "${post.slug}": no matching member for author_id ${post.author_id}`);
+          continue;
+        }
+
         const rendered = await renderMarkdown(post.body);
         store.set({
           id: post.slug,
           data: {
             title: post.title,
             date: new Date(post.date),
-            author: post.author,
+            author,
           },
           body: post.body,
           rendered,

--- a/src/pages/admin/events/[slug]/edit.astro
+++ b/src/pages/admin/events/[slug]/edit.astro
@@ -4,6 +4,7 @@ import AdminLayout from "../../../../layouts/AdminLayout.astro";
 import EventForm from "../../../../components/EventForm/EventForm";
 import type { EventFormInitialData } from "../../../../components/EventForm/EventForm";
 import { supabase } from "../../../../lib/supabase";
+import { unwrapRelation } from "../../../../lib/supabaseRelations";
 import "../../../../styles/form.css";
 
 const { slug } = Astro.params;
@@ -20,8 +21,8 @@ if (error || !event) {
 
 const dateStr = new Date(event.date).toISOString().slice(0, 16);
 
-const venue = Array.isArray(event.venues) ? event.venues[0] : event.venues;
-const location = Array.isArray(event.locations) ? event.locations[0] : event.locations;
+const venue = unwrapRelation(event.venues);
+const location = unwrapRelation(event.locations);
 
 const initialData: EventFormInitialData = {
   name: event.name,

--- a/src/pages/admin/posts.astro
+++ b/src/pages/admin/posts.astro
@@ -3,6 +3,7 @@ export const prerender = false;
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import { getCollection } from "astro:content";
 import { formatBlogDate } from "../../utils/script";
+import { getDisplayName } from "../../lib/memberDisplay";
 import "../../styles/form.css";
 
 const posts = (await getCollection("blog")).sort(
@@ -32,7 +33,7 @@ const posts = (await getCollection("blog")).sort(
           <tr>
             <td data-label="Title">{post.data.title}</td>
             <td data-label="Date">{formatBlogDate(post.data.date)}</td>
-            <td data-label="Author">{post.data.author}</td>
+            <td data-label="Author">{getDisplayName(post.data.author)}</td>
             <td><a href={`/admin/posts/${post.id}/edit`}>Edit</a></td>
           </tr>
         ))}

--- a/src/pages/admin/posts/[slug]/edit.astro
+++ b/src/pages/admin/posts/[slug]/edit.astro
@@ -14,7 +14,7 @@ if (!supabaseAdmin) {
 
 const { data: post, error } = await supabaseAdmin
   .from("posts")
-  .select("id, title, slug, author, date, body")
+  .select("id, title, slug, date, body")
   .eq("slug", slug!)
   .single();
 
@@ -27,7 +27,6 @@ const dateStr = new Date(post.date).toISOString().slice(0, 10);
 const initialData: PostFormInitialData = {
   title: post.title,
   slug: post.slug,
-  author: post.author,
   date: dateStr,
   body: post.body,
 };

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -5,6 +5,7 @@ import { formatEventDate } from "../../utils/script";
 import "../../styles/event.css";
 import { getCollection } from "astro:content";
 import Banner from "../../layouts/Banner.astro";
+import { getDisplayName } from "../../lib/memberDisplay";
 
 export async function getStaticPaths() {
   const events = await getCollection("event");
@@ -104,6 +105,11 @@ const { event } = Astro.props;
         </ul>
       </div>
     )}
+    <div class="cnf-event-page__details">
+      <span class="cnf-event-page__details-info"
+        >Hosted by <a href={`/profile/${event.data.creator.username}`}>{getDisplayName(event.data.creator)}</a></span
+      >
+    </div>
   </section>
   <Banner
     title="Like to suggest a topic?"

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -3,6 +3,7 @@ export const prerender = true;
 import { getCollection, render } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { formatBlogDate } from "../../utils/script";
+import { getDisplayName } from "../../lib/memberDisplay";
 import Banner from "../../layouts/Banner.astro";
 
 export async function getStaticPaths() {
@@ -32,7 +33,7 @@ const { Content } = await render(post);
   <section class="cnf-section">
     <h1>{post.data.title}</h1>
     <div class="cnf-post__details">
-      {post.data.author} &#8226; {formatBlogDate(post.data.date)}
+      <a href={`/profile/${post.data.author.username}`}>{getDisplayName(post.data.author)}</a> &#8226; {formatBlogDate(post.data.date)}
     </div>
     <Content />
   </section>

--- a/src/pages/profile/[username].astro
+++ b/src/pages/profile/[username].astro
@@ -4,12 +4,24 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getSessionToken, verifySessionToken } from "../../lib/auth";
 import { supabaseAdmin } from "../../lib/supabase";
 import { getDisplayName } from "../../lib/memberDisplay";
+import { getCollection } from "astro:content";
+import BlogEntry from "../../components/BlogEntry.astro";
 
 const { username } = Astro.params;
 
-const { data: profileUser } = supabaseAdmin
-  ? await supabaseAdmin.from("members").select("username, full_name, display_full_name, created_at").eq("username", username).single()
-  : { data: null };
+const token = getSessionToken(Astro.request);
+const payload = token ? verifySessionToken(token) : null;
+
+// Independent lookups (profile being viewed vs. the logged-in viewer, if
+// any) — run in parallel rather than one after another.
+const [{ data: profileUser }, { data: currentMember }] = await Promise.all([
+  supabaseAdmin
+    ? supabaseAdmin.from("members").select("username, full_name, display_full_name, created_at").eq("username", username).single()
+    : Promise.resolve({ data: null }),
+  payload && supabaseAdmin
+    ? supabaseAdmin.from("members").select("username").eq("id", payload.memberId).single()
+    : Promise.resolve({ data: null }),
+]);
 
 if (!profileUser) {
   Astro.response.status = 404;
@@ -21,16 +33,13 @@ const memberSince = profileUser
   ? new Date(profileUser.created_at).toLocaleDateString("en-IE", { day: "numeric", month: "short", year: "numeric" })
   : null;
 
-const token = getSessionToken(Astro.request);
-const payload = token ? verifySessionToken(token) : null;
+const isOwnProfile = Boolean(payload && profileUser && currentMember?.username === profileUser.username);
 
-let isOwnProfile = false;
-if (payload && profileUser) {
-  const { data: currentMember } = supabaseAdmin
-    ? await supabaseAdmin.from("members").select("username").eq("id", payload.memberId).single()
-    : { data: null };
-  isOwnProfile = currentMember?.username.toLowerCase() === profileUser.username.toLowerCase();
-}
+const authoredPosts = profileUser
+  ? (await getCollection("blog"))
+      .filter((post) => post.data.author.username === profileUser.username)
+      .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+  : [];
 ---
 
 <BaseLayout pageTitle={profileUser ? displayName : "Profile not found"}>
@@ -41,6 +50,16 @@ if (payload && profileUser) {
         <p>Member since: {memberSince}</p>
         {isOwnProfile && (
           <p><a href="/profile/edit">Edit your info</a></p>
+        )}
+        {authoredPosts.length > 0 && (
+          <>
+            <h2>Posts</h2>
+            <ul class="cnf-latest-blogs">
+              {authoredPosts.map((post) => (
+                <BlogEntry url={`/posts/${post.id}`} post={post.data} />
+              ))}
+            </ul>
+          </>
         )}
       </>
     ) : (

--- a/supabase/migrations/20260818122525_add_author_id_and_created_by.sql
+++ b/supabase/migrations/20260818122525_add_author_id_and_created_by.sql
@@ -1,0 +1,34 @@
+-- Issue #29: link post authors and event creators to members
+--
+-- Posts: replace free-text `author` with a proper FK to members.
+alter table public.posts add column author_id uuid references public.members(id);
+
+-- Events: add `created_by` FK to members.
+alter table public.events add column created_by uuid references public.members(id);
+
+-- Backfill: Francis has been the only post author and event creator to
+-- date (confirmed 2026-08-18), so both columns default every existing row
+-- to his account. Resolved case-insensitively by username, matching the
+-- app's own uniqueness rule (members_username_lower_idx is on
+-- lower(username)) rather than a case-sensitive literal match. Raises a
+-- clear error if this is run against an environment without that member,
+-- instead of silently leaving the columns null and failing opaquely at
+-- the `set not null` step below.
+do $$
+declare
+  francis_id uuid;
+begin
+  select id into francis_id from public.members where lower(username) = lower('ephcue');
+
+  if francis_id is null then
+    raise exception 'Backfill expects a member with username ''ephcue'' to exist (Francis has been the only post author/event creator so far). Adjust this migration before running it against an environment without that member.';
+  end if;
+
+  update public.posts set author_id = francis_id where author_id is null;
+  update public.events set created_by = francis_id where created_by is null;
+end $$;
+
+alter table public.posts alter column author_id set not null;
+alter table public.posts drop column author;
+
+alter table public.events alter column created_by set not null;


### PR DESCRIPTION
Closes #29.

## Summary
- `posts.author` (free text) replaced with `author_id`, a FK to `members`, auto-set from the logged-in admin on create (immutable after — never reassigned on edit, same as `events.created_by`).
- `events` gets a new `created_by` FK to `members`, auto-set on create.
- Backfill: all existing posts matched to Francis by `full_name" (he's been the only author); all existing events defaulted to his account.
- Display: post detail page and event detail page now link the author/creator to `/profile/<username>`. Admin post list and the profile page itself show the plain display name (no link, per the 'detail page only' scope decided for #29). Event's 'Hosted by' line sits at the bottom of the page content.
- Profile page now shows a **Posts** section, only rendered when the member has actually authored posts, styled to match the homepage's latest-posts widget.
- `updateUsername` now also fires the Netlify build hook (same one `createPost`/`updatePost`/`createEvent`/`updateEvent` already use), so a display-name change propagates into already-built posts/events instead of staying stale until an unrelated rebuild.

## Migration
`supabase/migrations/20260818122525_add_author_id_and_created_by.sql` — applied directly via the SQL editor and repaired into the remote migration history (`supabase migration repair --status applied`) so `supabase db push` stays in sync going forward.

## Testing
- `astro check`: 0 errors
- `vitest`: 101/101 passing (updated `PostForm.test.tsx` for the removed author field)
- Manually verified in dev: author/creator links resolve, profile Posts section shows/hides correctly, display-name propagation confirmed after a content resync