### PR TITLE
Remove hardcoded Discussion label from event page

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -42,7 +42,6 @@ const { event } = Astro.props;
               ? <span class="cnf-event-page__details-info">{event.data.venue.name}</span>
               : null
       }
-      <span class="cnf-event-page__details-info">Discussion</span>
     </div>
     {event.data.description && (
       <div class="cnf-event-page__description">


### PR DESCRIPTION
Closes #44.

Removes the static "Discussion" label from the event detail page's details row — there's no real event-type data driving it, so it's just dead copy.