### PR TITLE
Show @username under full name on profile page

### DIFF
--- a/src/pages/profile/[username].astro
+++ b/src/pages/profile/[username].astro
@@ -6,6 +6,7 @@ import { supabaseAdmin } from "../../lib/supabase";
 import { getDisplayName } from "../../lib/memberDisplay";
 import { getCollection } from "astro:content";
 import BlogEntry from "../../components/BlogEntry.astro";
+import "../../styles/profile.css";
 
 const { username } = Astro.params;
 
@@ -28,6 +29,7 @@ if (!profileUser) {
 }
 
 const displayName = profileUser ? getDisplayName(profileUser) : null;
+const showHandle = profileUser ? displayName !== profileUser.username : false;
 
 const memberSince = profileUser
   ? new Date(profileUser.created_at).toLocaleDateString("en-IE", { day: "numeric", month: "short", year: "numeric" })
@@ -47,6 +49,7 @@ const authoredPosts = profileUser
     {profileUser ? (
       <>
         <h1>{displayName}</h1>
+        {showHandle && <p class="cnf-profile__handle">@{profileUser.username}</p>}
         <p>Member since: {memberSince}</p>
         {isOwnProfile && (
           <p><a href="/profile/edit">Edit your info</a></p>

--- a/src/styles/profile.css
+++ b/src/styles/profile.css
@@ -1,0 +1,8 @@
+.cnf-profile__handle {
+  color: hsl(var(--color-grey));
+  margin-top: 0;
+}
+
+h1:has(+ .cnf-profile__handle) {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Closes #45.

Adds a secondary grey `@username` line directly below the `<h1>` on the profile page, shown only when `display_full_name` is true and a full name is actually being displayed (i.e. the handle isn't already the `<h1>`). Plain text, no link. New `profile.css` also tightens the h1/handle spacing so the handle sits directly under the name.