### PR TITLE
feat: scope events to a club, close #36

### DIFF
--- a/src/actions/events.ts
+++ b/src/actions/events.ts
@@ -4,11 +4,13 @@ import { sendMailchimpEmail } from '../lib/mailchimp';
 import { requireAdmin } from '../lib/auth';
 import { triggerNetlifyBuild } from '../lib/netlifyBuildHook';
 
-type ResolvedVenue = { id: number; name: string; url: string | null };
+type ResolvedVenue = { id: number; name: string; url: string | null; club_id: number };
 
 // Resolves the venue for a non-online event: an existing venue is looked up
 // by id as-is, a "New venue…" submission (name + club, no id yet) is
 // upserted. Returns null when the event is online or no venue was picked.
+// `club_id` comes back on the venue itself — a venue always belongs to
+// exactly one club, so that's also the event's hosting club (see #36).
 async function resolveVenue(formData: FormData, is_online: boolean): Promise<ResolvedVenue | null> {
   if (is_online) return null;
 
@@ -18,7 +20,7 @@ async function resolveVenue(formData: FormData, is_online: boolean): Promise<Res
   if (selected_venue_id) {
     const { data: venue, error } = await supabaseAdmin!
       .from('venues')
-      .select('id, name, url')
+      .select('id, name, url, club_id')
       .eq('id', selected_venue_id)
       .single();
 
@@ -34,11 +36,23 @@ async function resolveVenue(formData: FormData, is_online: boolean): Promise<Res
   const { data: venue, error } = await supabaseAdmin!
     .from('venues')
     .upsert({ name: location_name, url: location_url, club_id }, { onConflict: 'name,club_id' })
-    .select('id, name, url')
+    .select('id, name, url, club_id')
     .single();
 
   if (error) throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
   return venue;
+}
+
+// In-person: the hosting club is the venue's own club, not a separate
+// choice — a venue always belongs to exactly one club. Online: no venue to
+// derive it from, so it's an explicit form field, left null for a
+// genuinely cross-chapter/global event (see #36).
+function resolveEventClubId(formData: FormData, is_online: boolean, venue: ResolvedVenue | null): number | null {
+  if (is_online) {
+    const submitted = formData.get('event_club_id');
+    return submitted ? Number(submitted) : null;
+  }
+  return venue?.club_id ?? null;
 }
 
 export const createEvent = defineAction({
@@ -68,6 +82,7 @@ export const createEvent = defineAction({
     }
 
     const venue = await resolveVenue(formData, is_online);
+    const event_club_id = resolveEventClubId(formData, is_online, venue);
 
     const { error } = await supabaseAdmin
       .from('events')
@@ -77,6 +92,7 @@ export const createEvent = defineAction({
         slug,
         is_online,
         venue_id: venue?.id ?? null,
+        club_id: event_club_id,
         created_by: admin.memberId,
         meeting_url,
         instagram: (formData.get('instagram') as string) || null,
@@ -129,6 +145,7 @@ export const updateEvent = defineAction({
     }
 
     const venue = await resolveVenue(formData, is_online);
+    const event_club_id = resolveEventClubId(formData, is_online, venue);
 
     const { error } = await supabaseAdmin
       .from('events')
@@ -137,6 +154,7 @@ export const updateEvent = defineAction({
         date,
         is_online,
         venue_id: venue?.id ?? null,
+        club_id: event_club_id,
         meeting_url,
         instagram: (formData.get('instagram') as string) || null,
         facebook: (formData.get('facebook') as string) || null,

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -14,6 +14,7 @@ export type EventFormInitialData = {
   slug: string;
   isOnline?: boolean;
   venueId?: number;
+  eventClubId?: number;
   meetingUrl?: string;
   instagram?: string;
   facebook?: string;
@@ -134,18 +135,42 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
       </div>
 
       {isOnline ? (
-        <div className="cnf-form__group">
-          <label className="cnf-form__label" htmlFor="meeting_url">
-            Meeting URL
-          </label>
-          <input
-            className="cnf-form__input"
-            type="url"
-            id="meeting_url"
-            name="meeting_url"
-            defaultValue={initialData?.meetingUrl ?? DEFAULT_MEETING_URL}
-          />
-        </div>
+        <>
+          <div className="cnf-form__group">
+            <label className="cnf-form__label" htmlFor="event_club_id">
+              Hosting club
+            </label>
+            <select
+              className="cnf-form__input"
+              id="event_club_id"
+              name="event_club_id"
+              defaultValue={initialData?.eventClubId ? String(initialData.eventClubId) : ""}
+            >
+              <option value="">No specific chapter</option>
+              {clubs.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+            <small className="cnf-form__hint">
+              Which chapter is organizing this event.
+            </small>
+          </div>
+
+          <div className="cnf-form__group">
+            <label className="cnf-form__label" htmlFor="meeting_url">
+              Meeting URL
+            </label>
+            <input
+              className="cnf-form__input"
+              type="url"
+              id="meeting_url"
+              name="meeting_url"
+              defaultValue={initialData?.meetingUrl ?? DEFAULT_MEETING_URL}
+            />
+          </div>
+        </>
       ) : (
         <div className="cnf-form__group">
           <label className="cnf-form__label" htmlFor="venue_select">
@@ -164,7 +189,7 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
               onChange={(e) => setSelectedVenueId(e.target.value)}
               required
             >
-              <option value="">— select —</option>
+              <option value="">Select a venue</option>
               {venues.map((v) => (
                 <option key={v.id} value={String(v.id)}>
                   {v.name}
@@ -196,7 +221,7 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
               Club *
             </label>
             <select className="cnf-form__input" id="club_id" name="club_id" required>
-              <option value="">— select —</option>
+              <option value="">Select a club</option>
               {clubs.map((c) => (
                 <option key={c.id} value={c.id}>
                   {c.name}

--- a/src/lib/mailchimp.ts
+++ b/src/lib/mailchimp.ts
@@ -229,6 +229,16 @@ async function sendCampaign({ subjectLine, previewText, html }: {
   previewText: string;
   html: string;
 }): Promise<void> {
+  // Never hit the real Mailchimp account from a local dev server, even if
+  // a real API key is present in .env (e.g. pulled down via sync-env) —
+  // creating draft campaigns while testing locally would clutter the live
+  // account. Astro sets DEV based on how the app is actually running, not
+  // on env-var presence, so there's nothing to remember to unset.
+  if (import.meta.env.DEV) {
+    console.warn(`Mailchimp campaign skipped in local dev: "${subjectLine}"`);
+    return;
+  }
+
   const authHeader = `Basic ${Buffer.from(`any:${MAILCHIMP_API_KEY}`).toString('base64')}`;
   const baseUrl = `https://${DC}.api.mailchimp.com/3.0`;
 

--- a/src/pages/admin/events/[slug]/edit.astro
+++ b/src/pages/admin/events/[slug]/edit.astro
@@ -11,7 +11,7 @@ const { slug } = Astro.params;
 
 const { data: event, error } = await supabase!
   .from("events")
-  .select("id, name, date, slug, is_online, venue_id, meeting_url, instagram, facebook, meetup, description, summary, venues(id, name, url)")
+  .select("id, name, date, slug, is_online, venue_id, club_id, meeting_url, instagram, facebook, meetup, description, summary, venues(id, name, url)")
   .eq("slug", slug!)
   .single();
 
@@ -29,6 +29,7 @@ const initialData: EventFormInitialData = {
   slug: event.slug,
   isOnline: event.is_online,
   venueId: venue?.id,
+  eventClubId: event.club_id ?? undefined,
   meetingUrl: event.meeting_url ?? undefined,
   instagram: event.instagram ?? undefined,
   facebook: event.facebook ?? undefined,

--- a/supabase/migrations/20260820100000_add_club_id_to_events.sql
+++ b/supabase/migrations/20260820100000_add_club_id_to_events.sql
@@ -1,0 +1,26 @@
+-- Issue #36: scope events to a specific club.
+--
+-- `club_id` is nullable by design, not a strict "every event must belong
+-- to one chapter" FK: a non-null value means a specific club organizes the
+-- event (in-person or online), null means a genuinely cross-chapter/global
+-- event (e.g. one Francis hosts himself, not tied to any single chapter) —
+-- same idea as `posts` staying unscoped. See #52 for the events-page
+-- filtering/display follow-up this enables.
+alter table public.events add column club_id integer references public.clubs(id);
+
+-- Backfill: every event to date, online or in-person, was run by the one
+-- club (Trieste) — see #34's/#29's migrations for the same backfill
+-- pattern. Raises a clear error if that club is missing, instead of
+-- silently leaving every existing row unscoped.
+do $$
+declare
+  trieste_id integer;
+begin
+  select id into trieste_id from public.clubs where slug = 'trieste';
+
+  if trieste_id is null then
+    raise exception 'Backfill expects a club with slug ''trieste'' to exist (every event to date was run by that club). Adjust this migration before running it against an environment without that club.';
+  end if;
+
+  update public.events set club_id = trieste_id where club_id is null;
+end $$;


### PR DESCRIPTION
Adds nullable `club_id` to `events`, backfilled to Trieste.

- In-person events derive `club_id` from their venue's own club (a venue always belongs to one club) — no separate selector, so it can't contradict the venue.
- Online events get an explicit hosting-club selector, left unset ("No specific chapter") for a genuinely global/cross-chapter event.
- Also skips Mailchimp campaign creation entirely in local dev (`import.meta.env.DEV`), so testing locally never touches the live Mailchimp account regardless of `.env` contents.

Closes #36. Full test checklist run manually before opening this — see session notes.