### PR TITLE
Per-club admin roles

### DIFF
--- a/src/actions/events.ts
+++ b/src/actions/events.ts
@@ -1,17 +1,27 @@
 import { defineAction, ActionError } from 'astro:actions';
 import { supabase, supabaseAdmin } from '../lib/supabase';
 import { sendMailchimpEmail } from '../lib/mailchimp';
-import { requireAdmin } from '../lib/auth';
+import { requireAdmin, isClubInScope, scopeToAdminClubs, type AdminScope } from '../lib/auth';
 import { triggerNetlifyBuild } from '../lib/netlifyBuildHook';
 
 type ResolvedVenue = { id: number; name: string; url: string | null; club_id: number };
+
+// #37: throwing wrapper around the shared isClubInScope predicate, for the
+// server-action call sites below (resolveVenue/resolveEventClubId/updateEvent).
+function assertClubInScope(admin: AdminScope, club_id: number | null) {
+  if (isClubInScope(admin, club_id)) return;
+  throw new ActionError({ code: 'FORBIDDEN', message: 'You are not an admin of that club' });
+}
 
 // Resolves the venue for a non-online event: an existing venue is looked up
 // by id as-is, a "New venue…" submission (name + club, no id yet) is
 // upserted. Returns null when the event is online or no venue was picked.
 // `club_id` comes back on the venue itself — a venue always belongs to
 // exactly one club, so that's also the event's hosting club (see #36).
-async function resolveVenue(formData: FormData, is_online: boolean): Promise<ResolvedVenue | null> {
+// Every path is checked against the caller's admin scope (#37) so a
+// club-scoped admin can't attach an event to, or create a venue under, a
+// club they don't administer.
+async function resolveVenue(formData: FormData, is_online: boolean, admin: AdminScope): Promise<ResolvedVenue | null> {
   if (is_online) return null;
 
   const selected_venue_id = formData.get('venue_id')
@@ -25,12 +35,14 @@ async function resolveVenue(formData: FormData, is_online: boolean): Promise<Res
       .single();
 
     if (error) throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
+    assertClubInScope(admin, venue.club_id);
     return venue;
   }
 
   const club_id = formData.get('club_id') ? Number(formData.get('club_id')) : null;
   const location_name = (formData.get('location_name') as string) || null;
   if (!club_id || !location_name) return null;
+  assertClubInScope(admin, club_id);
 
   const location_url = (formData.get('location_url') as string) || null;
   const { data: venue, error } = await supabaseAdmin!
@@ -44,15 +56,28 @@ async function resolveVenue(formData: FormData, is_online: boolean): Promise<Res
 }
 
 // In-person: the hosting club is the venue's own club, not a separate
-// choice — a venue always belongs to exactly one club. Online: no venue to
-// derive it from, so it's an explicit form field, left null for a
-// genuinely cross-chapter/global event (see #36).
-function resolveEventClubId(formData: FormData, is_online: boolean, venue: ResolvedVenue | null): number | null {
+// choice — a venue always belongs to exactly one club, already scope-checked
+// in resolveVenue. Online: no venue to derive it from, so it's an explicit
+// form field. Either way, a null result (genuinely cross-chapter/global, see
+// #36 - no venue picked counts as the same thing) is only allowed for a
+// super admin, since a club-scoped admin has no standing to create an event
+// outside every club they administer.
+function resolveEventClubId(formData: FormData, is_online: boolean, venue: ResolvedVenue | null, admin: AdminScope): number | null {
   if (is_online) {
     const submitted = formData.get('event_club_id');
-    return submitted ? Number(submitted) : null;
+    if (!submitted) {
+      assertClubInScope(admin, null);
+      return null;
+    }
+    const club_id = Number(submitted);
+    assertClubInScope(admin, club_id);
+    return club_id;
   }
-  return venue?.club_id ?? null;
+  if (!venue) {
+    assertClubInScope(admin, null);
+    return null;
+  }
+  return venue.club_id;
 }
 
 export const createEvent = defineAction({
@@ -81,8 +106,8 @@ export const createEvent = defineAction({
       throw new ActionError({ code: 'BAD_REQUEST', message: 'Slug must contain only lowercase letters, numbers and hyphens' });
     }
 
-    const venue = await resolveVenue(formData, is_online);
-    const event_club_id = resolveEventClubId(formData, is_online, venue);
+    const venue = await resolveVenue(formData, is_online, admin);
+    const event_club_id = resolveEventClubId(formData, is_online, venue, admin);
 
     const { error } = await supabaseAdmin
       .from('events')
@@ -126,7 +151,8 @@ export const createEvent = defineAction({
 export const updateEvent = defineAction({
   accept: 'form',
   handler: async (formData, context) => {
-    if (!(await requireAdmin(context.request))) {
+    const admin = await requireAdmin(context.request);
+    if (!admin) {
       throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
     }
 
@@ -144,8 +170,19 @@ export const updateEvent = defineAction({
       throw new ActionError({ code: 'BAD_REQUEST', message: 'Missing required fields' });
     }
 
-    const venue = await resolveVenue(formData, is_online);
-    const event_club_id = resolveEventClubId(formData, is_online, venue);
+    // A club-scoped admin also can't be allowed to edit an event they don't
+    // currently administer, even if their submitted new venue/club would
+    // otherwise pass scope - check the event's existing club before touching it.
+    const { data: existing, error: existingError } = await supabaseAdmin
+      .from('events')
+      .select('club_id')
+      .eq('slug', slug)
+      .single();
+    if (existingError) throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: existingError.message });
+    assertClubInScope(admin, existing.club_id);
+
+    const venue = await resolveVenue(formData, is_online, admin);
+    const event_club_id = resolveEventClubId(formData, is_online, venue, admin);
 
     const { error } = await supabaseAdmin
       .from('events')
@@ -174,16 +211,22 @@ export const updateEvent = defineAction({
   }
 });
 
+// #37: only used by the admin-only EventForm, so now gated and scoped like
+// getVenues below - a club-scoped admin should only ever see the clubs they
+// administer in the hosting-club/new-venue-club dropdowns.
 export const getClubs = defineAction({
-  handler: async () => {
+  handler: async (_, context) => {
+    const admin = await requireAdmin(context.request);
+    if (!admin) {
+      throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
+    }
+
     if (!supabase) {
       throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Supabase not configured' });
     }
 
-    const { data, error } = await supabase
-      .from('clubs')
-      .select('id, name')
-      .order('name');
+    const query = scopeToAdminClubs(supabase.from('clubs').select('id, name').order('name'), admin, 'id');
+    const { data, error } = await query;
 
     if (error) throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
     return data ?? [];
@@ -192,7 +235,8 @@ export const getClubs = defineAction({
 
 export const getVenues = defineAction({
   handler: async (_, context) => {
-    if (!(await requireAdmin(context.request))) {
+    const admin = await requireAdmin(context.request);
+    if (!admin) {
       throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
     }
 
@@ -200,10 +244,8 @@ export const getVenues = defineAction({
       throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Supabase not configured' });
     }
 
-    const { data, error } = await supabase
-      .from('venues')
-      .select('id, name, url, club_id')
-      .order('name');
+    const query = scopeToAdminClubs(supabase.from('venues').select('id, name, url, club_id').order('name'), admin, 'club_id');
+    const { data, error } = await query;
 
     if (error) throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
     return data ?? [];

--- a/src/components/EventForm/EventForm.test.tsx
+++ b/src/components/EventForm/EventForm.test.tsx
@@ -37,7 +37,7 @@ describe("EventForm (create mode)", () => {
   });
 
   it("renders all required form fields", () => {
-    render(<EventForm mode="create" />);
+    render(<EventForm mode="create" isSuperAdmin />);
     expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/date & time/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/url slug/i)).toBeInTheDocument();
@@ -45,22 +45,36 @@ describe("EventForm (create mode)", () => {
   });
 
   it("shows the venue field, not a meeting URL field, by default", () => {
-    render(<EventForm mode="create" />);
+    render(<EventForm mode="create" isSuperAdmin />);
     expect(screen.getByRole("checkbox", { name: /this event is online/i })).not.toBeChecked();
     expect(screen.getByLabelText(/^venue/i)).toBeInTheDocument();
     expect(screen.queryByLabelText(/meeting url/i)).not.toBeInTheDocument();
   });
 
   it("shows the meeting URL field, not the venue field, once online is checked", () => {
-    render(<EventForm mode="create" />);
+    render(<EventForm mode="create" isSuperAdmin />);
     fireEvent.click(screen.getByRole("checkbox", { name: /this event is online/i }));
     expect(screen.getByLabelText(/meeting url/i)).toBeInTheDocument();
     expect(screen.queryByLabelText(/^venue/i)).not.toBeInTheDocument();
   });
 
+  it("offers 'No specific chapter' for a super admin's online event", () => {
+    render(<EventForm mode="create" isSuperAdmin />);
+    fireEvent.click(screen.getByRole("checkbox", { name: /this event is online/i }));
+    expect(screen.getByLabelText(/hosting club/i)).not.toBeRequired();
+    expect(screen.getByText("No specific chapter")).toBeInTheDocument();
+  });
+
+  it("hides 'No specific chapter' and requires a hosting club for a club-scoped admin", () => {
+    render(<EventForm mode="create" isSuperAdmin={false} />);
+    fireEvent.click(screen.getByRole("checkbox", { name: /this event is online/i }));
+    expect(screen.getByLabelText(/hosting club/i)).toBeRequired();
+    expect(screen.queryByText("No specific chapter")).not.toBeInTheDocument();
+  });
+
   it("disables submit button while submitting", async () => {
     mockCreateEvent.mockReturnValue(new Promise(() => {}));
-    render(<EventForm mode="create" />);
+    render(<EventForm mode="create" isSuperAdmin />);
 
     await waitForVenuesToLoad();
     fireEvent.submit(document.querySelector("form")!);
@@ -72,7 +86,7 @@ describe("EventForm (create mode)", () => {
 
   it("shows error message when action returns an error", async () => {
     mockCreateEvent.mockResolvedValue({ error: { message: "Slug already exists" } });
-    render(<EventForm mode="create" />);
+    render(<EventForm mode="create" isSuperAdmin />);
 
     await waitForVenuesToLoad();
     fireEvent.submit(document.querySelector("form")!);
@@ -84,7 +98,7 @@ describe("EventForm (create mode)", () => {
 
   it("shows success message when event is created", async () => {
     mockCreateEvent.mockResolvedValue({ data: { success: true } });
-    render(<EventForm mode="create" />);
+    render(<EventForm mode="create" isSuperAdmin />);
 
     await waitForVenuesToLoad();
     fireEvent.submit(document.querySelector("form")!);
@@ -103,25 +117,25 @@ describe("EventForm (edit mode)", () => {
   });
 
   it("renders 'Save changes' button instead of 'Create'", () => {
-    render(<EventForm mode="edit" initialData={sampleInitialData} />);
+    render(<EventForm mode="edit" initialData={sampleInitialData} isSuperAdmin />);
     expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^create$/i })).not.toBeInTheDocument();
   });
 
   it("pre-populates name and date from initialData", () => {
-    render(<EventForm mode="edit" initialData={sampleInitialData} />);
+    render(<EventForm mode="edit" initialData={sampleInitialData} isSuperAdmin />);
     expect(screen.getByLabelText(/title/i)).toHaveValue("Test Event");
     expect(screen.getByLabelText(/date & time/i)).toHaveValue("2025-06-01T19:00");
   });
 
   it("pre-checks the online checkbox from initialData.isOnline", () => {
-    render(<EventForm mode="edit" initialData={{ ...sampleInitialData, isOnline: true }} />);
+    render(<EventForm mode="edit" initialData={{ ...sampleInitialData, isOnline: true }} isSuperAdmin />);
     expect(screen.getByRole("checkbox", { name: /this event is online/i })).toBeChecked();
     expect(screen.getByLabelText(/meeting url/i)).toBeInTheDocument();
   });
 
   it("displays slug as read-only", () => {
-    render(<EventForm mode="edit" initialData={sampleInitialData} />);
+    render(<EventForm mode="edit" initialData={sampleInitialData} isSuperAdmin />);
     const slugInput = screen.getByRole("textbox", { name: /url slug/i });
     expect(slugInput).toHaveAttribute("readOnly");
     expect(slugInput).toHaveValue("test-event");
@@ -129,14 +143,14 @@ describe("EventForm (edit mode)", () => {
 
   it("disables submit button and shows loading placeholder while venues are loading", () => {
     mockGetVenues.mockReturnValue(new Promise(() => {}));
-    render(<EventForm mode="edit" initialData={sampleInitialData} />);
+    render(<EventForm mode="edit" initialData={sampleInitialData} isSuperAdmin />);
 
     expect(screen.getByText("Loading venues…")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
   });
 
   it("enables submit button after venues load", async () => {
-    render(<EventForm mode="edit" initialData={sampleInitialData} />);
+    render(<EventForm mode="edit" initialData={sampleInitialData} isSuperAdmin />);
 
     await waitForVenuesToLoad();
 
@@ -145,7 +159,7 @@ describe("EventForm (edit mode)", () => {
 
   it("shows error message when updateEvent returns an error", async () => {
     mockUpdateEvent.mockResolvedValue({ error: { message: "Update failed" } });
-    render(<EventForm mode="edit" initialData={sampleInitialData} />);
+    render(<EventForm mode="edit" initialData={sampleInitialData} isSuperAdmin />);
 
     await waitForVenuesToLoad();
     fireEvent.submit(document.querySelector("form")!);
@@ -157,7 +171,7 @@ describe("EventForm (edit mode)", () => {
 
   it("shows success message after update", async () => {
     mockUpdateEvent.mockResolvedValue({ data: { success: true } });
-    render(<EventForm mode="edit" initialData={sampleInitialData} />);
+    render(<EventForm mode="edit" initialData={sampleInitialData} isSuperAdmin />);
 
     await waitForVenuesToLoad();
     fireEvent.submit(document.querySelector("form")!);
@@ -173,7 +187,7 @@ describe("EventForm (edit mode)", () => {
       { id: 6, name: "Another Venue", url: null, club_id: 1 },
     ];
     mockGetVenues.mockResolvedValue({ data: venues });
-    render(<EventForm mode="edit" initialData={{ ...sampleInitialData, venueId: 5 }} />);
+    render(<EventForm mode="edit" initialData={{ ...sampleInitialData, venueId: 5 }} isSuperAdmin />);
 
     await waitForVenuesToLoad();
 
@@ -183,7 +197,7 @@ describe("EventForm (edit mode)", () => {
   it("does not pre-select a venue when no venueId is provided", async () => {
     const venues = [{ id: 5, name: "The Philosophy Bar", url: null, club_id: 1 }];
     mockGetVenues.mockResolvedValue({ data: venues });
-    render(<EventForm mode="edit" initialData={sampleInitialData} />);
+    render(<EventForm mode="edit" initialData={sampleInitialData} isSuperAdmin />);
 
     await waitForVenuesToLoad();
 

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -26,9 +26,10 @@ export type EventFormInitialData = {
 type EventFormProps = {
   mode: "create" | "edit";
   initialData?: EventFormInitialData;
+  isSuperAdmin: boolean;
 };
 
-export default function EventForm({ mode, initialData }: EventFormProps) {
+export default function EventForm({ mode, initialData, isSuperAdmin }: EventFormProps) {
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [errorMessage, setErrorMessage] = useState("");
   const [isOnline, setIsOnline] = useState(initialData?.isOnline ?? false);
@@ -145,8 +146,9 @@ export default function EventForm({ mode, initialData }: EventFormProps) {
               id="event_club_id"
               name="event_club_id"
               defaultValue={initialData?.eventClubId ? String(initialData.eventClubId) : ""}
+              required={!isSuperAdmin}
             >
-              <option value="">No specific chapter</option>
+              {isSuperAdmin && <option value="">No specific chapter</option>}
               {clubs.map((c) => (
                 <option key={c.id} value={c.id}>
                   {c.name}

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// #37: getAdminScope/requireAdmin resolve super-admin vs per-club scope by
+// querying members/club_admins live - mock the two tables independently so
+// each test controls exactly what comes back, same shape as the real
+// supabase-js chain (`.from().select().eq()[.single()]`).
+const state = vi.hoisted(() => ({
+  members: null as { is_admin: boolean } | null,
+  clubAdmins: [] as { club_id: number }[],
+}));
+
+vi.mock("./supabase", () => ({
+  supabaseAdmin: {
+    from: (table: string) => {
+      if (table === "members") {
+        return { select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: state.members }) }) }) };
+      }
+      if (table === "club_admins") {
+        return { select: () => ({ eq: () => Promise.resolve({ data: state.clubAdmins }) }) };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  },
+}));
+
+import { getAdminScope, requireAdmin, createSessionToken, isClubInScope } from "./auth";
+
+// Mocking ./supabase (above) also skips its `import "dotenv/config"` side
+// effect, so JWT_SECRET never gets loaded from .env - set it directly
+// instead of relying on that transitive load.
+process.env.JWT_SECRET ??= "test-secret";
+
+function makeRequest(cookie: string): Request {
+  return { headers: { get: (name: string) => (name.toLowerCase() === "cookie" ? cookie : null) } } as unknown as Request;
+}
+
+beforeEach(() => {
+  state.members = null;
+  state.clubAdmins = [];
+});
+
+describe("getAdminScope", () => {
+  it("grants isSuperAdmin with no clubIds when members.is_admin is true", async () => {
+    state.members = { is_admin: true };
+    state.clubAdmins = [{ club_id: 1 }]; // should be ignored once super admin is found
+
+    const scope = await getAdminScope("member-1");
+
+    expect(scope).toEqual({ memberId: "member-1", isSuperAdmin: true, clubIds: [] });
+  });
+
+  it("resolves clubIds from club_admins when not a super admin", async () => {
+    state.members = { is_admin: false };
+    state.clubAdmins = [{ club_id: 1 }, { club_id: 2 }];
+
+    const scope = await getAdminScope("member-2");
+
+    expect(scope).toEqual({ memberId: "member-2", isSuperAdmin: false, clubIds: [1, 2] });
+  });
+
+  it("fails closed with no rights when the member row is missing", async () => {
+    state.members = null;
+
+    const scope = await getAdminScope("ghost");
+
+    expect(scope).toEqual({ memberId: "ghost", isSuperAdmin: false, clubIds: [] });
+  });
+});
+
+describe("requireAdmin", () => {
+  it("returns null when there is no session cookie", async () => {
+    expect(await requireAdmin(makeRequest(""))).toBeNull();
+  });
+
+  it("returns the scope for a super admin", async () => {
+    state.members = { is_admin: true };
+    const token = createSessionToken("member-1", true);
+
+    const scope = await requireAdmin(makeRequest(`session=${token}`));
+
+    expect(scope).toEqual({ memberId: "member-1", isSuperAdmin: true, clubIds: [] });
+  });
+
+  it("returns the scope for a club-scoped (non-super) admin", async () => {
+    state.members = { is_admin: false };
+    state.clubAdmins = [{ club_id: 3 }];
+    const token = createSessionToken("member-2", false);
+
+    const scope = await requireAdmin(makeRequest(`session=${token}`));
+
+    expect(scope).toEqual({ memberId: "member-2", isSuperAdmin: false, clubIds: [3] });
+  });
+
+  it("returns null for a member with no super-admin flag and no club_admins rows", async () => {
+    state.members = { is_admin: false };
+    state.clubAdmins = [];
+    const token = createSessionToken("member-3", false);
+
+    expect(await requireAdmin(makeRequest(`session=${token}`))).toBeNull();
+  });
+});
+
+describe("isClubInScope", () => {
+  const superAdmin = { memberId: "m1", isSuperAdmin: true, clubIds: [] };
+  const clubScoped = { memberId: "m2", isSuperAdmin: false, clubIds: [1, 2] };
+
+  it("lets a super admin touch any club, including a null (global) one", () => {
+    expect(isClubInScope(superAdmin, 1)).toBe(true);
+    expect(isClubInScope(superAdmin, 99)).toBe(true);
+    expect(isClubInScope(superAdmin, null)).toBe(true);
+  });
+
+  it("lets a club-scoped admin touch only the clubs they administer", () => {
+    expect(isClubInScope(clubScoped, 1)).toBe(true);
+    expect(isClubInScope(clubScoped, 3)).toBe(false);
+  });
+
+  // Regression: a club-scoped admin must not be able to leave something
+  // unscoped (null club_id) just by omitting a club - that's equivalent to
+  // the "no specific chapter" option, which only a super admin may pick.
+  it("never lets a club-scoped admin touch a null (global) club", () => {
+    expect(isClubInScope(clubScoped, null)).toBe(false);
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -72,28 +72,76 @@ export function verifySessionToken(token: string): { memberId: string; isAdmin: 
   }
 }
 
-// The token's own isAdmin claim is fine for cosmetic reads (e.g. showing/hiding
-// a nav link) but anything that actually GATES access should call this instead:
-// it checks the members table live, so revoking admin rights takes effect on
-// the very next request instead of waiting out the token's 30-day expiry.
-// Fails closed - a missing Supabase client, a query error, or no matching row
-// (payload.memberId always comes from a verified token, but data can still be
-// deleted or misconfigured) all resolve to "not admin".
-export async function isMemberAdmin(memberId: string): Promise<boolean> {
-  if (!supabaseAdmin) return false;
-  const { data } = await supabaseAdmin.from("members").select("is_admin").eq("id", memberId).single();
-  return !!data?.is_admin;
+// A member's admin scope: a super admin (members.is_admin) manages every
+// club, so clubIds is meaningless for them and left empty - callers must
+// check isSuperAdmin first. A non-super admin's scope is exactly the clubs
+// in club_admins; empty means they hold no admin rights over any club (e.g.
+// admin status was fully revoked, or - shouldn't happen once #37 ships with
+// no self-serve grant path - a member row with no super-admin flag and no
+// club_admins rows at all).
+export type AdminScope = { memberId: string; isSuperAdmin: boolean; clubIds: number[] };
+
+// Resolves a member's full admin scope: super-admin status plus, if not a
+// super admin, the specific clubs they administer via club_admins. The
+// token's own isAdmin claim is fine for cosmetic reads (e.g. showing/hiding
+// a nav link) but anything that actually GATES access should call this
+// instead: it checks live, so revoking rights takes effect on the very next
+// request instead of waiting out the token's 30-day expiry. Fails closed - a
+// missing Supabase client, a query error, or no matching row (memberId
+// always comes from a verified token, but data can still be deleted or
+// misconfigured) all resolve to no rights at all.
+export async function getAdminScope(memberId: string): Promise<AdminScope> {
+  const none = { memberId, isSuperAdmin: false, clubIds: [] };
+  if (!supabaseAdmin) return none;
+
+  const { data: member } = await supabaseAdmin.from("members").select("is_admin").eq("id", memberId).single();
+  if (!member) return none;
+  if (member.is_admin) return { memberId, isSuperAdmin: true, clubIds: [] };
+
+  const { data: clubAdmins } = await supabaseAdmin.from("club_admins").select("club_id").eq("member_id", memberId);
+  return { memberId, isSuperAdmin: false, clubIds: (clubAdmins ?? []).map((row) => row.club_id) };
 }
 
 // Single admin-gate check shared by middleware and every admin-only action.
-// Extracts and verifies the session cookie, then confirms admin status live
-// via isMemberAdmin. Returns the payload when authorized, null otherwise -
-// callers decide how to respond (redirect vs. throw ActionError).
-export async function requireAdmin(request: Request): Promise<{ memberId: string; isAdmin: boolean } | null> {
+// Extracts and verifies the session cookie, then resolves the caller's full
+// admin scope (super admin, or the specific clubs they administer) live via
+// getAdminScope. Returns the scope when authorized (super admin, or admin of
+// at least one club), null otherwise - callers decide how to respond
+// (redirect vs. throw ActionError). Actions that need to enforce per-club
+// scoping (not just "is this member an admin at all") should read
+// isSuperAdmin/clubIds off the returned scope directly.
+export async function requireAdmin(request: Request): Promise<AdminScope | null> {
   const token = getSessionToken(request);
   const payload = token ? verifySessionToken(token) : null;
-  if (!payload || !(await isMemberAdmin(payload.memberId))) return null;
-  return payload;
+  if (!payload) return null;
+
+  const scope = await getAdminScope(payload.memberId);
+  if (!scope.isSuperAdmin && scope.clubIds.length === 0) return null;
+  return scope;
+}
+
+// A non-super admin may only touch clubs they administer - a null club_id
+// (genuinely cross-chapter/global, see #36) is out of scope for them too,
+// since it isn't any specific club they administer. Shared by every place
+// that gates access to one specific club (an existing venue/event's club, a
+// submitted event_club_id/new-venue club_id, an event about to be viewed or
+// edited) so the rule can't drift between call sites. A plain predicate
+// rather than a throw - callers fail however fits their context (an
+// ActionError in a server action, a redirect on an Astro page).
+export function isClubInScope(admin: AdminScope, club_id: number | null): boolean {
+  return admin.isSuperAdmin || (club_id !== null && admin.clubIds.includes(club_id));
+}
+
+// Narrows any Supabase query builder to a super admin's full access, or a
+// club-scoped admin's own clubs via the given column - the one "scope this
+// list to the caller's clubs" shape shared by getClubs/getVenues/the admin
+// events list, instead of each repeating the isSuperAdmin branch itself.
+// Q is left unconstrained (not `Q extends {in(...): Q}`) and the `.in` call
+// is asserted locally instead - constraining Q directly against Supabase's
+// real builder type sends TS's inference into an infinite loop (ts(2589)).
+export function scopeToAdminClubs<Q>(query: Q, admin: AdminScope, column: string): Q {
+  if (admin.isSuperAdmin) return query;
+  return (query as unknown as { in(column: string, values: number[]): Q }).in(column, admin.clubIds);
 }
 
 // Safari (unlike Chrome) refuses to store cookies marked Secure over plain HTTP,

--- a/src/pages/admin/create-event.astro
+++ b/src/pages/admin/create-event.astro
@@ -2,7 +2,12 @@
 export const prerender = false;
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import EventForm from "../../components/EventForm/EventForm";
+import { requireAdmin } from "../../lib/auth";
 import "../../styles/form.css";
+
+// #37: only a super admin may leave an event unscoped ("No specific
+// chapter") - EventForm needs to know which to show that option.
+const admin = (await requireAdmin(Astro.request))!;
 ---
 
 <AdminLayout pageTitle="Create Event">
@@ -11,6 +16,6 @@ import "../../styles/form.css";
       <h1>Create event</h1>
       <a href="/admin/events">Back to events</a>
     </div>
-    <EventForm mode="create" client:load />
+    <EventForm mode="create" isSuperAdmin={admin.isSuperAdmin} client:load />
   </section>
 </AdminLayout>

--- a/src/pages/admin/events.astro
+++ b/src/pages/admin/events.astro
@@ -1,14 +1,32 @@
 ---
 export const prerender = false;
 import AdminLayout from "../../layouts/AdminLayout.astro";
-import { getCollection } from "astro:content";
-import type { EventCollection } from "../../types/types";
+import { supabaseAdmin } from "../../lib/supabase";
+import { requireAdmin, scopeToAdminClubs } from "../../lib/auth";
+import { unwrapRelation } from "../../lib/supabaseRelations";
 import { formatBlogDate } from "../../utils/script";
 
-const events = (await getCollection("event")) as EventCollection[];
-const sorted = [...events].sort(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime()
+// #37: scoped to the caller's clubs, so this can no longer read from the
+// events content collection (its loader drops club_id) - queries Supabase
+// directly instead, same pattern as the edit page.
+const admin = (await requireAdmin(Astro.request))!;
+
+const query = scopeToAdminClubs(
+  supabaseAdmin!.from("events").select("name, date, slug, is_online, club_id, venues(name)").order("date", { ascending: false }),
+  admin,
+  "club_id"
 );
+const { data, error } = await query;
+// Fails to an empty list rather than crashing the whole admin dashboard on a
+// transient Supabase error - this is a read-only listing, not a single
+// record the page can't render without.
+if (error) console.error("Failed to load admin events list:", error.message);
+
+const sorted = (data ?? []).map((event) => ({
+  ...event,
+  date: new Date(event.date),
+  venue: unwrapRelation(event.venues),
+}));
 ---
 
 <AdminLayout pageTitle="Events">
@@ -31,10 +49,10 @@ const sorted = [...events].sort(
       <tbody>
         {sorted.map((event) => (
           <tr>
-            <td data-label="Name">{event.data.name}</td>
-            <td data-label="Date">{formatBlogDate(event.data.date)}</td>
-            <td data-label="Location">{event.data.isOnline ? "Online" : event.data.location?.name ?? "—"}</td>
-            <td><a href={`/admin/events/${event.data.slug}/edit`}>Edit</a></td>
+            <td data-label="Name">{event.name}</td>
+            <td data-label="Date">{formatBlogDate(event.date)}</td>
+            <td data-label="Location">{event.is_online ? "Online" : event.venue?.name ?? "—"}</td>
+            <td><a href={`/admin/events/${event.slug}/edit`}>Edit</a></td>
           </tr>
         ))}
       </tbody>

--- a/src/pages/admin/events/[slug]/edit.astro
+++ b/src/pages/admin/events/[slug]/edit.astro
@@ -4,8 +4,13 @@ import AdminLayout from "../../../../layouts/AdminLayout.astro";
 import EventForm from "../../../../components/EventForm/EventForm";
 import type { EventFormInitialData } from "../../../../components/EventForm/EventForm";
 import { supabase } from "../../../../lib/supabase";
+import { requireAdmin, isClubInScope } from "../../../../lib/auth";
 import { unwrapRelation } from "../../../../lib/supabaseRelations";
 import "../../../../styles/form.css";
+
+// #37: only a super admin may leave an event unscoped ("No specific
+// chapter") - EventForm needs to know which to show that option.
+const admin = (await requireAdmin(Astro.request))!;
 
 const { slug } = Astro.params;
 
@@ -15,7 +20,11 @@ const { data: event, error } = await supabase!
   .eq("slug", slug!)
   .single();
 
-if (error || !event) {
+// A club-scoped admin has no standing to even view an event outside their
+// clubs, not just to save changes to it (updateEvent already enforces that
+// side) - same redirect as a genuinely missing event, no distinct "forbidden"
+// state to avoid confirming a slug's existence to an admin who can't see it.
+if (error || !event || !isClubInScope(admin, event.club_id)) {
   return Astro.redirect("/admin/events");
 }
 
@@ -45,6 +54,6 @@ const initialData: EventFormInitialData = {
       <h1>Edit event</h1>
       <a href="/admin/events">Back to events</a>
     </div>
-    <EventForm mode="edit" initialData={initialData} client:load />
+    <EventForm mode="edit" initialData={initialData} isSuperAdmin={admin.isSuperAdmin} client:load />
   </section>
 </AdminLayout>

--- a/supabase/migrations/20260824100000_add_club_admins.sql
+++ b/supabase/migrations/20260824100000_add_club_admins.sql
@@ -1,0 +1,31 @@
+-- Issue #37: per-club admin roles.
+--
+-- `members.is_admin` stays as the super-admin override (manages every club).
+-- This new join table layers per-club admin rights on top: a member can be
+-- an admin of one or more specific clubs without being a super admin.
+create table public.club_admins (
+  member_id  uuid    not null references public.members(id) on delete cascade,
+  club_id    integer not null references public.clubs(id) on delete cascade,
+  created_at timestamp with time zone default now(),
+  primary key (member_id, club_id)
+);
+
+alter table public.club_admins enable row level security;
+
+-- Backfill: every member who is currently a super admin also gets a
+-- club_admins row for Trieste, so nothing regresses if super-admin is ever
+-- removed from someone later — same backfill pattern as #34/#36.
+do $$
+declare
+  trieste_id integer;
+begin
+  select id into trieste_id from public.clubs where slug = 'trieste';
+
+  if trieste_id is null then
+    raise exception 'Backfill expects a club with slug ''trieste'' to exist (every current admin is scoped to that club). Adjust this migration before running it against an environment without that club.';
+  end if;
+
+  insert into public.club_admins (member_id, club_id)
+  select id, trieste_id from public.members where is_admin = true
+  on conflict (member_id, club_id) do nothing;
+end $$;


### PR DESCRIPTION
Closes #37.

- New `club_admins(member_id, club_id)` join table (migration already applied live); `members.is_admin` stays the super-admin override, backfilled every current super admin into Trieste.
- `requireAdmin` now resolves and returns full scope (`{memberId, isSuperAdmin, clubIds}`) instead of the raw JWT payload — single choke point everything else reads off.
- `getClubs`/`getVenues` gated + scoped to the caller's clubs (feeds `EventForm`'s dropdowns).
- `createEvent`/`updateEvent` reject a submitted venue/club outside the caller's scope; `updateEvent` also checks the *event's existing* club before allowing any edit.
- `admin/events.astro` switched from the (club_id-dropping) content-collection loader to a direct scoped Supabase query, same pattern the edit page already used.
- `EventForm` hides the unscoped "No specific chapter" option (and requires a hosting club) for non-super admins — only a super admin may leave an event unscoped.
- No `members.astro` UI for assigning `club_admins` yet — stays manual/super-admin-only, same as founding a chapter.

Tests: 114/114 passing (7 new in `auth.test.ts` for scope resolution, 2 new in `EventForm.test.tsx` for the hidden-option behavior). `astro check` clean.