### PR TITLE
Treat online events as global on the public site

### DIFF
--- a/src/loaders/events.ts
+++ b/src/loaders/events.ts
@@ -35,7 +35,22 @@ export function eventsLoader(): Loader {
         // resolveEventClubId in src/actions/events.ts), null meaning
         // genuinely cross-chapter/global. No need to derive it from the
         // venue relation separately.
-        const location = event.club_id ? clubsMap.get(event.club_id) ?? null : null;
+        //
+        // #60: online events are always treated as global on the public
+        // site regardless of club_id — an online event isn't tied to a
+        // physical place, so it reuses the same "location: null is visible
+        // on every chapter" plumbing #39 built for genuinely cross-chapter
+        // events (clubSlugsForEvent, canonical URLs, etc.), rather than only
+        // showing up under whichever single chapter organizes it. club_id
+        // itself is left untouched in the DB for admin/internal purposes —
+        // only this public-facing `location` is forced null. This is a
+        // temporary simplification pending #52's per-chapter online filter;
+        // revisit once that ships.
+        const location = event.is_online
+          ? null
+          : event.club_id
+            ? clubsMap.get(event.club_id) ?? null
+            : null;
         const creator = unwrapRelation(event.members);
 
         if (!creator) {


### PR DESCRIPTION
Closes #60.

An online event's `club_id` (set via an explicit form field, see #37/#39) picks who *organizes* it, but that shouldn't decide which chapter's events page it *shows up on* — an online event isn't tied to a physical place. Currently, filtering the events page by a specific chapter (e.g. Trieste) only shows online events that happen to be pinned to that chapter, and hides ones pinned elsewhere.

**Change:** in the events loader, force `location = null` for any `isOnline` event, regardless of `club_id`. This reuses the existing global-event plumbing #39 already built (`clubSlugsForEvent`, the two `getStaticPaths` functions, the canonical-URL logic on the event detail page) instead of introducing a new concept — so every online event now shows under every chapter's events page.

`club_id` itself is untouched in the DB — still there for admin/internal "who organizes this" purposes (admin dashboard scoping, edit-access checks). Only the public-facing `location` field is affected.

**Not a reversal of #52.** #52's plan (a "Trieste → Online" sub-filter over just that chapter's own online events) stays valid future work. This PR is a temporary simplification for the period before #52 lands; worth revisiting "are all online events always global" once that ships.

Verified: full test suite (117 tests) and `astro check` pass; no test changes needed since the fixtures in `EventList.test.tsx` already model an online event as `location: null`.