### PR TITLE
Add RSVP feature for event availability

### DIFF
--- a/src/actions/events.test.ts
+++ b/src/actions/events.test.ts
@@ -1,0 +1,517 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Handler-level tests for createEvent/updateEvent/getClubs/getVenues, mirroring
+// the harness used in rsvps.test.ts: defineAction is mocked to return the
+// definition as-is (so the raw handler is directly invokable), ActionError is
+// stubbed with the real class's shape (code + message), and both Supabase
+// clients are mocked per table with state controlling each query's response.
+// requireAdmin is stubbed directly (rather than faking cookies/JWTs) since
+// isClubInScope/scopeToAdminClubs — the two scoping helpers this file actually
+// exercises — are pure and kept real via importOriginal. sendMailchimpEmail
+// and triggerNetlifyBuild are stubbed as plain side-effect recorders.
+const state = vi.hoisted(() => {
+  return {
+    supabaseConfigured: true,
+    // requireAdmin's resolved scope for the current test.
+    admin: null as { memberId: string; isSuperAdmin: boolean; clubIds: number[] } | null,
+
+    // events: insert (createEvent) / select+eq+single (updateEvent's existing-club
+    // check) / update+eq (updateEvent).
+    insertedEvent: null as Record<string, unknown> | null,
+    insertedEventRow: { id: 42 } as { id: number } | null,
+    eventInsertError: null as Error | null,
+    existingEvent: null as { club_id: number | null } | null,
+    existingEventError: null as Error | null,
+    updatedEvent: null as Record<string, unknown> | null,
+    eventUpdateError: null as Error | null,
+
+    // venues (admin client): existing-venue lookup + new-venue upsert, both used
+    // by resolveVenue.
+    venueById: null as { id: number; name: string; url: string | null; club_id: number } | null,
+    venueLookupError: null as Error | null,
+    upsertedVenuePayload: null as Record<string, unknown> | null,
+    upsertedVenueRow: null as { id: number; name: string; url: string | null; club_id: number } | null,
+    venueUpsertError: null as Error | null,
+
+    // clubs (admin client): slug lookup for the Mailchimp draft in createEvent.
+    clubBySlugLookup: null as { slug: string } | null,
+    clubLookupError: null as Error | null,
+
+    // rsvps (admin client): the host's seeded "going" row on createEvent.
+    rsvpInsertPayload: null as Record<string, unknown> | null,
+    rsvpInsertError: null as Error | null,
+
+    // clubs/venues (non-admin client): the scoped lists getClubs/getVenues return.
+    clubsList: [] as { id: number; name: string }[],
+    clubsListError: null as Error | null,
+    clubsScopeFilter: null as { col: string; vals: number[] } | null,
+    venuesList: [] as { id: number; name: string; url: string | null; club_id: number }[],
+    venuesListError: null as Error | null,
+    venuesScopeFilter: null as { col: string; vals: number[] } | null,
+
+    // side effects.
+    mailchimpCall: null as unknown,
+    mailchimpError: null as Error | null,
+    netlifyBuildCalled: false,
+  };
+});
+
+vi.mock('astro:actions', () => {
+  class MockActionError extends Error {
+    code: string;
+    constructor(params: { message?: string; code: string }) {
+      super(params.message);
+      this.name = 'ActionError';
+      this.code = params.code;
+    }
+  }
+  return {
+    defineAction: (definition: { accept?: string; handler: unknown }) => definition,
+    ActionError: MockActionError,
+  };
+});
+
+vi.mock('../lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/auth')>();
+  return {
+    ...actual,
+    requireAdmin: async () => state.admin,
+  };
+});
+
+vi.mock('../lib/mailchimp', () => ({
+  sendMailchimpEmail: (event: unknown) => {
+    state.mailchimpCall = event;
+    return state.mailchimpError ? Promise.reject(state.mailchimpError) : Promise.resolve();
+  },
+}));
+
+vi.mock('../lib/netlifyBuildHook', () => ({
+  triggerNetlifyBuild: () => {
+    state.netlifyBuildCalled = true;
+  },
+}));
+
+// A minimal thenable that scopeToAdminClubs can optionally call `.in(...)` on
+// before it's awaited — matches how a real Supabase query builder behaves
+// (each modifier returns something still awaitable).
+function scopableQuery(
+  result: { data: unknown; error: Error | null },
+  onIn: (col: string, vals: number[]) => void
+) {
+  const query = {
+    in: (col: string, vals: number[]) => {
+      onIn(col, vals);
+      return query;
+    },
+    then: (resolve: (v: typeof result) => void) => resolve(result),
+  };
+  return query;
+}
+
+vi.mock('../lib/supabase', () => {
+  const adminClient = {
+    from: (table: string) => {
+      if (table === 'events') {
+        return {
+          insert: (rows: Record<string, unknown>[]) => {
+            state.insertedEvent = rows[0] ?? null;
+            return {
+              select: () => ({
+                single: () =>
+                  state.eventInsertError
+                    ? Promise.resolve({ data: null, error: state.eventInsertError })
+                    : Promise.resolve({ data: state.insertedEventRow, error: null }),
+              }),
+            };
+          },
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                state.existingEventError
+                  ? Promise.resolve({ data: null, error: state.existingEventError })
+                  : Promise.resolve({ data: state.existingEvent, error: null }),
+            }),
+          }),
+          update: (patch: Record<string, unknown>) => {
+            state.updatedEvent = patch;
+            return { eq: () => Promise.resolve({ error: state.eventUpdateError }) };
+          },
+        };
+      }
+      if (table === 'venues') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                state.venueLookupError
+                  ? Promise.resolve({ data: null, error: state.venueLookupError })
+                  : Promise.resolve({ data: state.venueById, error: null }),
+            }),
+          }),
+          upsert: (row: Record<string, unknown>) => {
+            state.upsertedVenuePayload = row;
+            return {
+              select: () => ({
+                single: () =>
+                  state.venueUpsertError
+                    ? Promise.resolve({ data: null, error: state.venueUpsertError })
+                    : Promise.resolve({ data: state.upsertedVenueRow, error: null }),
+              }),
+            };
+          },
+        };
+      }
+      if (table === 'clubs') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                state.clubLookupError
+                  ? Promise.resolve({ data: null, error: state.clubLookupError })
+                  : Promise.resolve({ data: state.clubBySlugLookup, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'rsvps') {
+        return {
+          // createEvent seeds the host's RSVP through the same upsertRsvp
+          // helper setEventRsvp uses (see rsvps.test.ts) — an upsert, not a
+          // plain insert.
+          upsert: (row: Record<string, unknown>) => {
+            state.rsvpInsertPayload = row;
+            return Promise.resolve({ error: state.rsvpInsertError });
+          },
+        };
+      }
+      throw new Error(`Unexpected table (admin): ${table}`);
+    },
+  };
+
+  const nonAdminClient = {
+    from: (table: string) => {
+      if (table === 'clubs') {
+        return {
+          select: () => ({
+            order: () =>
+              scopableQuery(
+                state.clubsListError
+                  ? { data: null, error: state.clubsListError }
+                  : { data: state.clubsList, error: null },
+                (col, vals) => {
+                  state.clubsScopeFilter = { col, vals };
+                }
+              ),
+          }),
+        };
+      }
+      if (table === 'venues') {
+        return {
+          select: () => ({
+            order: () =>
+              scopableQuery(
+                state.venuesListError
+                  ? { data: null, error: state.venuesListError }
+                  : { data: state.venuesList, error: null },
+                (col, vals) => {
+                  state.venuesScopeFilter = { col, vals };
+                }
+              ),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table (non-admin): ${table}`);
+    },
+  };
+
+  return {
+    supabase: state.supabaseConfigured ? nonAdminClient : null,
+    supabaseAdmin: state.supabaseConfigured ? adminClient : null,
+  };
+});
+
+import { createEvent, updateEvent, getClubs, getVenues } from './events';
+import { DEFAULT_CLUB_SLUG } from '../lib/clubDefaults';
+
+type Ctx = { request: Request };
+type FormHandler = (formData: FormData, context: Ctx) => Promise<{ success: true }>;
+type QueryHandler = (input: undefined, context: Ctx) => Promise<unknown>;
+
+const createHandler = (createEvent as unknown as { handler: FormHandler }).handler;
+const updateHandler = (updateEvent as unknown as { handler: FormHandler }).handler;
+const getClubsHandler = (getClubs as unknown as { handler: QueryHandler }).handler;
+const getVenuesHandler = (getVenues as unknown as { handler: QueryHandler }).handler;
+
+function context(): Ctx {
+  return { request: new Request('https://example.com') };
+}
+
+function form(fields: Record<string, string>): FormData {
+  const data = new FormData();
+  for (const [key, value] of Object.entries(fields)) data.set(key, value);
+  return data;
+}
+
+const SUPER_ADMIN = { memberId: 'admin-1', isSuperAdmin: true, clubIds: [] as number[] };
+const CLUB_ADMIN = { memberId: 'admin-2', isSuperAdmin: false, clubIds: [3] };
+
+const ONLINE_FORM = {
+  name: 'Philosophy Night',
+  date: '2099-01-01T18:00:00.000Z',
+  slug: 'philosophy-night',
+  is_online: 'true',
+  meeting_url: 'https://meet.jit.si/x',
+};
+
+beforeEach(() => {
+  state.supabaseConfigured = true;
+  state.admin = null;
+  state.insertedEvent = null;
+  state.insertedEventRow = { id: 42 };
+  state.eventInsertError = null;
+  state.existingEvent = null;
+  state.existingEventError = null;
+  state.updatedEvent = null;
+  state.eventUpdateError = null;
+  state.venueById = null;
+  state.venueLookupError = null;
+  state.upsertedVenuePayload = null;
+  state.upsertedVenueRow = null;
+  state.venueUpsertError = null;
+  state.clubBySlugLookup = { slug: 'trieste' };
+  state.clubLookupError = null;
+  state.rsvpInsertPayload = null;
+  state.rsvpInsertError = null;
+  state.clubsList = [];
+  state.clubsListError = null;
+  state.clubsScopeFilter = null;
+  state.venuesList = [];
+  state.venuesListError = null;
+  state.venuesScopeFilter = null;
+  state.mailchimpCall = null;
+  state.mailchimpError = null;
+  state.netlifyBuildCalled = false;
+});
+
+describe('createEvent', () => {
+  it('throws UNAUTHORIZED without a valid admin session', async () => {
+    await expect(createHandler(form(ONLINE_FORM), context())).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('throws BAD_REQUEST for missing required fields', async () => {
+    state.admin = SUPER_ADMIN;
+
+    await expect(createHandler(form({ name: 'X' }), context())).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Missing required fields',
+    });
+  });
+
+  it('throws BAD_REQUEST for an invalid slug format', async () => {
+    state.admin = SUPER_ADMIN;
+
+    await expect(
+      createHandler(form({ ...ONLINE_FORM, slug: 'Not A Slug!' }), context())
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Slug must contain only lowercase letters, numbers and hyphens',
+    });
+  });
+
+  it('throws FORBIDDEN when a club-scoped admin picks a venue outside their clubs', async () => {
+    state.admin = CLUB_ADMIN; // clubIds: [3]
+    state.venueById = { id: 9, name: 'Elsewhere Hall', url: null, club_id: 7 };
+
+    await expect(
+      createHandler(form({ ...ONLINE_FORM, is_online: 'false', venue_id: '9' }), context())
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('creates an online event, seeds a going RSVP for the host, and returns success', async () => {
+    state.admin = SUPER_ADMIN;
+    state.insertedEventRow = { id: 42 };
+
+    const result = await createHandler(form(ONLINE_FORM), context());
+
+    expect(result).toEqual({ success: true });
+    expect(state.insertedEvent).toMatchObject({
+      name: 'Philosophy Night',
+      date: '2099-01-01T18:00:00.000Z',
+      slug: 'philosophy-night',
+      is_online: true,
+      venue_id: null,
+      club_id: null,
+      created_by: 'admin-1',
+      meeting_url: 'https://meet.jit.si/x',
+    });
+    // #27: the host is seeded as a real "going" row, not a bumped count —
+    // via the shared upsertRsvp helper, so it carries the same updated_at
+    // audit stamp as a member's own RSVP does.
+    expect(state.rsvpInsertPayload).toMatchObject({ member_id: 'admin-1', event_id: 42, status: 'going' });
+    expect(state.rsvpInsertPayload?.updated_at).toEqual(expect.any(String));
+    expect(state.netlifyBuildCalled).toBe(true);
+    expect(state.mailchimpCall).toMatchObject({ slug: 'philosophy-night', club_slug: DEFAULT_CLUB_SLUG });
+  });
+
+  it("creates an in-person event via an existing venue, using the venue's club", async () => {
+    state.admin = CLUB_ADMIN; // clubIds: [3]
+    state.venueById = { id: 5, name: 'The Reading Room', url: 'https://example.com/venue', club_id: 3 };
+    state.insertedEventRow = { id: 43 };
+    state.clubBySlugLookup = { slug: 'galway' };
+
+    const result = await createHandler(
+      form({
+        name: 'In-Person Talk',
+        date: '2099-02-01T18:00:00.000Z',
+        slug: 'in-person-talk',
+        is_online: 'false',
+        venue_id: '5',
+      }),
+      context()
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(state.insertedEvent).toMatchObject({ venue_id: 5, club_id: 3, created_by: 'admin-2' });
+    expect(state.rsvpInsertPayload).toMatchObject({ member_id: 'admin-2', event_id: 43, status: 'going' });
+    expect(state.mailchimpCall).toMatchObject({ club_slug: 'galway', venue_name: 'The Reading Room' });
+  });
+
+  it('still creates the event when seeding the host RSVP fails', async () => {
+    state.admin = SUPER_ADMIN;
+    state.rsvpInsertError = new Error('constraint violation');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await createHandler(form(ONLINE_FORM), context());
+
+    expect(result).toEqual({ success: true });
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it('still creates the event when the Mailchimp draft fails', async () => {
+    state.admin = SUPER_ADMIN;
+    state.mailchimpError = new Error('Mailchimp is down');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await createHandler(form(ONLINE_FORM), context());
+
+    expect(result).toEqual({ success: true });
+    consoleError.mockRestore();
+  });
+
+  it('throws INTERNAL_SERVER_ERROR when the event insert fails', async () => {
+    state.admin = SUPER_ADMIN;
+    state.eventInsertError = new Error('duplicate slug');
+
+    await expect(createHandler(form(ONLINE_FORM), context())).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+  });
+});
+
+describe('updateEvent', () => {
+  const UPDATE_FORM = {
+    name: 'Updated Name',
+    date: '2099-03-01T18:00:00.000Z',
+    slug: 'philosophy-night',
+    is_online: 'true',
+    meeting_url: 'https://meet.jit.si/y',
+  };
+
+  it('throws UNAUTHORIZED without a valid admin session', async () => {
+    await expect(updateHandler(form(UPDATE_FORM), context())).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('throws BAD_REQUEST for missing required fields', async () => {
+    state.admin = SUPER_ADMIN;
+
+    await expect(updateHandler(form({ slug: 'philosophy-night' }), context())).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('throws INTERNAL_SERVER_ERROR when the existing event lookup fails', async () => {
+    state.admin = SUPER_ADMIN;
+    state.existingEventError = new Error('not found');
+
+    await expect(updateHandler(form(UPDATE_FORM), context())).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+  });
+
+  it("throws FORBIDDEN when the admin isn't in scope for the event's existing club", async () => {
+    state.admin = CLUB_ADMIN; // clubIds: [3]
+    state.existingEvent = { club_id: 9 };
+
+    await expect(updateHandler(form(UPDATE_FORM), context())).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('updates the event and triggers a rebuild', async () => {
+    state.admin = SUPER_ADMIN;
+    state.existingEvent = { club_id: null };
+
+    const result = await updateHandler(form(UPDATE_FORM), context());
+
+    expect(result).toEqual({ success: true });
+    expect(state.updatedEvent).toMatchObject({ name: 'Updated Name', is_online: true });
+    expect(state.netlifyBuildCalled).toBe(true);
+    // Only createEvent seeds a host RSVP — updating an event never should.
+    expect(state.rsvpInsertPayload).toBeNull();
+  });
+
+  it('throws INTERNAL_SERVER_ERROR when the update fails', async () => {
+    state.admin = SUPER_ADMIN;
+    state.existingEvent = { club_id: null };
+    state.eventUpdateError = new Error('db down');
+
+    await expect(updateHandler(form(UPDATE_FORM), context())).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+  });
+});
+
+describe('getClubs', () => {
+  it('throws UNAUTHORIZED without a valid admin session', async () => {
+    await expect(getClubsHandler(undefined, context())).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('returns every club, unscoped, for a super admin', async () => {
+    state.admin = SUPER_ADMIN;
+    state.clubsList = [
+      { id: 1, name: 'Trieste' },
+      { id: 2, name: 'Galway' },
+    ];
+
+    const result = await getClubsHandler(undefined, context());
+
+    expect(result).toEqual(state.clubsList);
+    expect(state.clubsScopeFilter).toBeNull();
+  });
+
+  it("scopes the query to a club-scoped admin's own clubs", async () => {
+    state.admin = CLUB_ADMIN; // clubIds: [3]
+    state.clubsList = [{ id: 3, name: 'Galway' }];
+
+    const result = await getClubsHandler(undefined, context());
+
+    expect(result).toEqual(state.clubsList);
+    expect(state.clubsScopeFilter).toEqual({ col: 'id', vals: [3] });
+  });
+});
+
+describe('getVenues', () => {
+  it('throws UNAUTHORIZED without a valid admin session', async () => {
+    await expect(getVenuesHandler(undefined, context())).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it("scopes the query to a club-scoped admin's own clubs, by club_id", async () => {
+    state.admin = CLUB_ADMIN; // clubIds: [3]
+    state.venuesList = [{ id: 5, name: 'The Reading Room', url: null, club_id: 3 }];
+
+    const result = await getVenuesHandler(undefined, context());
+
+    expect(result).toEqual(state.venuesList);
+    expect(state.venuesScopeFilter).toEqual({ col: 'club_id', vals: [3] });
+  });
+});

--- a/src/actions/events.ts
+++ b/src/actions/events.ts
@@ -4,6 +4,7 @@ import { sendMailchimpEmail } from '../lib/mailchimp';
 import { requireAdmin, isClubInScope, scopeToAdminClubs, type AdminScope } from '../lib/auth';
 import { triggerNetlifyBuild } from '../lib/netlifyBuildHook';
 import { DEFAULT_CLUB_SLUG } from '../lib/clubDefaults';
+import { upsertRsvp } from './rsvps';
 
 type ResolvedVenue = { id: number; name: string; url: string | null; club_id: number };
 
@@ -110,7 +111,7 @@ export const createEvent = defineAction({
     const venue = await resolveVenue(formData, is_online, admin);
     const event_club_id = resolveEventClubId(formData, is_online, venue, admin);
 
-    const { error } = await supabaseAdmin
+    const { data: event, error } = await supabaseAdmin
       .from('events')
       .insert([{
         name,
@@ -132,6 +133,18 @@ export const createEvent = defineAction({
 
     if (error) {
       throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
+    }
+
+    // #27: the host is assumed to be attending their own event — seeded as a
+    // real RSVP row (not a bumped count) so it behaves like anyone else's:
+    // shows up in the named "Going" list, and the host can clear it later via
+    // the same RSVP widget if their plans change. Goes through the same
+    // write path setEventRsvp uses, so the row can't drift out of shape.
+    // Best-effort, like the Mailchimp draft below — shouldn't block event
+    // creation if it fails.
+    const { error: rsvpError } = await upsertRsvp(admin.memberId, event.id, 'going');
+    if (rsvpError) {
+      console.error(`Failed to seed host RSVP for event "${slug}":`, rsvpError.message);
     }
 
     triggerNetlifyBuild();

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -5,6 +5,7 @@ import { signup } from './signup';
 import { changePassword } from './changePassword';
 import { updateUsername } from './updateUsername';
 import { updateClubMemberships } from './clubMembers';
+import { getEventRsvps, setEventRsvp } from './rsvps';
 
 export const server = {
   createEvent,
@@ -18,4 +19,6 @@ export const server = {
   changePassword,
   updateUsername,
   updateClubMemberships,
+  getEventRsvps,
+  setEventRsvp,
 };

--- a/src/actions/rsvps.test.ts
+++ b/src/actions/rsvps.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Handler-level tests for getEventRsvps/setEventRsvp, mirroring the harness
+// used in events.test.ts: defineAction is mocked to return the definition
+// as-is (so the raw handler is directly invokable), ActionError is stubbed
+// with the real class's shape (code + message), and the Supabase admin
+// client is mocked per table with state controlling each query's response.
+// verifySessionToken is stubbed against a fixed token so auth paths are
+// exercised without JWT plumbing; getDisplayName (pure) is left real.
+const state = vi.hoisted(() => {
+  return {
+    supabaseConfigured: true,
+    // getEventRsvps/setEventRsvp both read the session cookie from context.
+    sessionCookie: null as string | null,
+    // events: slug lookup (.eq('slug').single()).
+    eventId: null as unknown as { id: number } | null,
+    eventLookupError: null as Error | null,
+    // rsvps: select rows for an event (.eq('event_id')).
+    rsvpRows: [] as {
+      member_id: string;
+      status: string;
+      members: { username: string; full_name: string | null; display_full_name: boolean } | null;
+    }[],
+    rsvpFetchError: null as Error | null,
+    // rsvps: the row setEventRsvp tried to upsert (captured for assertions).
+    upsertedRow: null as Record<string, unknown> | null,
+    upsertError: null as Error | null,
+    // rsvps: the (member_id, event_id) filter setEventRsvp deleted by (captured for assertions).
+    deletedFilter: null as Record<string, unknown> | null,
+    deleteError: null as Error | null,
+  };
+});
+
+vi.mock('astro:actions', () => {
+  class MockActionError extends Error {
+    code: string;
+    constructor(params: { message?: string; code: string }) {
+      super(params.message);
+      this.name = 'ActionError';
+      this.code = params.code;
+    }
+  }
+  return {
+    defineAction: (definition: { accept?: string; handler: unknown }) => definition,
+    ActionError: MockActionError,
+  };
+});
+
+vi.mock('../lib/supabase', () => {
+  const admin = {
+    from: (table: string) => {
+      if (table === 'events') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                state.eventLookupError
+                  ? Promise.resolve({ data: null, error: state.eventLookupError })
+                  : Promise.resolve({ data: state.eventId, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'rsvps') {
+        return {
+          select: () => ({
+            eq: () =>
+              state.rsvpFetchError
+                ? Promise.resolve({ data: null, error: state.rsvpFetchError })
+                : Promise.resolve({ data: state.rsvpRows, error: null }),
+          }),
+          upsert: (rows: Record<string, unknown> | Record<string, unknown>[]) => {
+            state.upsertedRow = Array.isArray(rows) ? (rows[0] ?? null) : rows;
+            return { error: state.upsertError };
+          },
+          delete: () => ({
+            eq: (col1: string, val1: unknown) => ({
+              eq: (col2: string, val2: unknown) => {
+                state.deletedFilter = { [col1]: val1, [col2]: val2 };
+                return Promise.resolve({ error: state.deleteError });
+              },
+            }),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  };
+  return {
+    supabase: null,
+    supabaseAdmin: state.supabaseConfigured ? admin : null,
+  };
+});
+
+vi.mock('../lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/auth')>();
+  return {
+    ...actual,
+    verifySessionToken: (token: string | undefined) =>
+      token === 'session-member-1' ? { memberId: 'member-1', isAdmin: false } : null,
+  };
+});
+
+import { getEventRsvps, setEventRsvp } from './rsvps';
+import type { RsvpState } from '../lib/rsvpTypes';
+
+type Handler<I> = (input: I, context: { cookies: { get(name: string): { value?: string } | undefined } }) => Promise<RsvpState>;
+const getHandler = (getEventRsvps as unknown as { handler: Handler<{ slug: string }> }).handler;
+const setHandler = (setEventRsvp as unknown as { handler: Handler<{ slug: string; status: string | null }> }).handler;
+
+function context(): { cookies: { get(name: string): { value?: string } | undefined } } {
+  return {
+    cookies: {
+      get: (name: string) => (name === 'session' && state.sessionCookie ? { value: state.sessionCookie } : undefined),
+    },
+  };
+}
+
+const MEMBER_ALICE = { username: 'alice', full_name: null, display_full_name: false };
+const MEMBER_BOB = { username: 'bob', full_name: 'Bob Smith', display_full_name: true };
+const MEMBER_CAROL = { username: 'carol', full_name: null, display_full_name: false };
+
+beforeEach(() => {
+  state.supabaseConfigured = true;
+  state.sessionCookie = null;
+  state.eventId = { id: 10 };
+  state.eventLookupError = null;
+  state.rsvpRows = [];
+  state.rsvpFetchError = null;
+  state.upsertedRow = null;
+  state.upsertError = null;
+  state.deletedFilter = null;
+  state.deleteError = null;
+});
+
+describe('getEventRsvps', () => {
+  it('returns aggregate counts but no identifiable data for an anonymous visitor', async () => {
+    state.rsvpRows = [
+      { member_id: 'member-1', status: 'going', members: MEMBER_ALICE },
+      { member_id: 'member-2', status: 'going', members: MEMBER_BOB },
+      { member_id: 'member-3', status: 'maybe', members: MEMBER_CAROL },
+      { member_id: 'member-4', status: 'not_going', members: MEMBER_ALICE },
+    ];
+
+    const result = await getHandler({ slug: 'philosophy-101' }, context());
+
+    expect(result).toEqual({
+      counts: { going: 2, maybe: 1, not_going: 1 },
+      myStatus: null,
+      lists: null,
+    });
+  });
+
+  it('returns the named breakdowns and the member own status for a logged-in member', async () => {
+    state.sessionCookie = 'session-member-1';
+    state.rsvpRows = [
+      { member_id: 'member-1', status: 'going', members: MEMBER_ALICE },
+      { member_id: 'member-2', status: 'going', members: MEMBER_BOB },
+      { member_id: 'member-3', status: 'maybe', members: MEMBER_CAROL },
+    ];
+
+    const result = await getHandler({ slug: 'philosophy-101' }, context());
+
+    expect(result).toEqual({
+      counts: { going: 2, maybe: 1, not_going: 0 },
+      myStatus: 'going',
+      lists: {
+        going: [MEMBER_ALICE, MEMBER_BOB],
+        maybe: [MEMBER_CAROL],
+        not_going: [] as typeof MEMBER_ALICE[],
+      },
+    });
+  });
+
+  it('sorts named lists by display name', async () => {
+    state.sessionCookie = 'session-member-1';
+    state.rsvpRows = [
+      { member_id: 'member-1', status: 'going', members: MEMBER_ALICE },
+      { member_id: 'member-2', status: 'going', members: MEMBER_BOB },
+    ];
+
+    const result = await getHandler({ slug: 'philosophy-101' }, context());
+
+    // "alice" sorts before "Bob Smith" case-sensitively, but getDisplayName
+    // resolves display_full_name members to their full name — deterministic
+    // ordering matters more than the exact collation here.
+    expect(result.lists).not.toBeNull();
+    expect(result.lists?.going.map((m) => m.username)).toEqual(['alice', 'bob']);
+  });
+
+  it('skips rows whose member relation is missing, still counting the rest', async () => {
+    state.sessionCookie = 'session-member-1';
+    state.rsvpRows = [
+      { member_id: 'member-1', status: 'going', members: MEMBER_ALICE },
+      { member_id: 'ghost', status: 'going', members: null },
+    ];
+
+    const result = await getHandler({ slug: 'philosophy-101' }, context());
+
+    expect(result.counts).toEqual({ going: 1, maybe: 0, not_going: 0 });
+  });
+
+  it('throws BAD_REQUEST for an unknown event slug', async () => {
+    state.eventId = null;
+    state.eventLookupError = new Error('PGRST116: no rows');
+
+    await expect(getHandler({ slug: 'nope' }, context())).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Event not found',
+    });
+  });
+
+  it('throws BAD_REQUEST for a missing slug', async () => {
+    await expect(getHandler({ slug: '' }, context())).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+});
+
+describe('setEventRsvp', () => {
+  it('throws UNAUTHORIZED for a visitor without a session', async () => {
+    await expect(setHandler({ slug: 'philosophy-101', status: 'going' }, context())).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('throws BAD_REQUEST for an invalid status', async () => {
+    state.sessionCookie = 'session-member-1';
+    await expect(setHandler({ slug: 'philosophy-101', status: 'definitely' }, context())).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('upserts the member event row and returns the fresh state', async () => {
+    state.sessionCookie = 'session-member-1';
+    const submittedAt = new Date().toISOString();
+    state.upsertError = null;
+    // Simulate what the DB looks like right after the upsert: the member's
+    // own going row plus one other member who is maybe.
+    state.rsvpRows = [
+      { member_id: 'member-1', status: 'going', members: MEMBER_ALICE },
+      { member_id: 'member-3', status: 'maybe', members: MEMBER_CAROL },
+    ];
+
+    const result = await setHandler({ slug: 'philosophy-101', status: 'going' }, context());
+
+    expect(state.upsertedRow).toMatchObject({
+      member_id: 'member-1',
+      event_id: 10,
+      status: 'going',
+    });
+    expect(typeof state.upsertedRow?.updated_at).toBe('string');
+    expect(new Date(String(state.upsertedRow?.updated_at)).getTime()).toBeGreaterThanOrEqual(
+      new Date(submittedAt).getTime() - 1
+    );
+
+    expect(result).toEqual({
+      counts: { going: 1, maybe: 1, not_going: 0 },
+      myStatus: 'going',
+      lists: {
+        going: [MEMBER_ALICE],
+        maybe: [MEMBER_CAROL],
+        not_going: [],
+      },
+    });
+  });
+
+  it('deletes the member row and returns the fresh state, when status is null', async () => {
+    state.sessionCookie = 'session-member-1';
+    // Simulate what the DB looks like right after the delete: the member's
+    // own row is gone, one other member's "maybe" remains.
+    state.rsvpRows = [{ member_id: 'member-3', status: 'maybe', members: MEMBER_CAROL }];
+
+    const result = await setHandler({ slug: 'philosophy-101', status: null }, context());
+
+    expect(state.deletedFilter).toEqual({ member_id: 'member-1', event_id: 10 });
+    expect(state.upsertedRow).toBeNull();
+
+    expect(result).toEqual({
+      counts: { going: 0, maybe: 1, not_going: 0 },
+      myStatus: null,
+      lists: {
+        going: [],
+        maybe: [MEMBER_CAROL],
+        not_going: [],
+      },
+    });
+  });
+
+  it('throws INTERNAL_SERVER_ERROR for a failed delete', async () => {
+    state.sessionCookie = 'session-member-1';
+    state.deleteError = new Error('disk full');
+
+    await expect(setHandler({ slug: 'philosophy-101', status: null }, context())).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+  });
+
+  it('throws BAD_REQUEST for an unknown event slug', async () => {
+    state.sessionCookie = 'session-member-1';
+    state.eventId = null;
+    state.eventLookupError = new Error('PGRST116: no rows');
+
+    await expect(setHandler({ slug: 'nope', status: 'going' }, context())).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Event not found',
+    });
+  });
+
+  it('throws INTERNAL_SERVER_ERROR for a failed upsert', async () => {
+    state.sessionCookie = 'session-member-1';
+    state.upsertError = new Error('disk full');
+
+    await expect(setHandler({ slug: 'philosophy-101', status: 'maybe' }, context())).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+  });
+});

--- a/src/actions/rsvps.ts
+++ b/src/actions/rsvps.ts
@@ -1,0 +1,184 @@
+import { defineAction, ActionError } from 'astro:actions';
+import { supabaseAdmin } from '../lib/supabase';
+import { verifySessionToken } from '../lib/auth';
+import { unwrapRelation } from '../lib/supabaseRelations';
+import { getDisplayName } from '../lib/memberDisplay';
+import {
+  isRsvpStatus,
+  type RsvpCounts,
+  type RsvpLists,
+  type RsvpMember,
+  type RsvpState,
+  type RsvpStatus,
+} from '../lib/rsvpTypes';
+
+type RsvpRow = {
+  member_id: string;
+  status: RsvpStatus;
+  // Only rows with a resolvable member survive fetchRsvpRows' filter, so a
+  // built state never holds a row whose member came back null (a deleted
+  // member would leave a dangling FK unless the FK's ON DELETE CASCADE ran).
+  members: RsvpMember;
+};
+
+// Resolves an event's id from its slug, rejecting unknown slugs up front so a
+// stale/tampered page gets a clear 400 instead of an opaque FK/empty-result
+// failure further down.
+async function resolveEventId(slug: string): Promise<number> {
+  const { data, error } = await supabaseAdmin!
+    .from('events')
+    .select('id')
+    .eq('slug', slug)
+    .single();
+
+  if (error || !data) {
+    throw new ActionError({ code: 'BAD_REQUEST', message: 'Event not found' });
+  }
+  return data.id;
+}
+
+async function fetchRsvpRows(eventId: number): Promise<RsvpRow[]> {
+  const { data, error } = await supabaseAdmin!
+    .from('rsvps')
+    .select('member_id, status, members(username, full_name, display_full_name)')
+    .eq('event_id', eventId);
+
+  if (error) {
+    throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
+  }
+
+  // #27: members who respond "not_going" are still counted alongside the
+  // "going"/"maybe" heads, so a status the schema CHECK already guarantees is
+  // kept as-is while a (theoretically impossible) stray row is skipped rather
+  // than crashing the aggregation.
+  return (data ?? [])
+    .map((row) => ({
+      member_id: row.member_id,
+      status: row.status,
+      members: unwrapRelation<RsvpMember>(row.members),
+    }))
+    .filter(
+      (row): row is RsvpRow =>
+        typeof row.member_id === 'string' &&
+        row.members !== null &&
+        isRsvpStatus(row.status)
+    );
+}
+
+// Builds the page-level RSVP state from the event's raw rows:
+//   - `counts` are aggregate and public (always returned).
+//   - `lists` + `myStatus` are member-only — built only when a memberId is
+//     supplied, so an anonymous visitor can never learn who rsvp'd.
+function buildRsvpState(rows: RsvpRow[], memberId: string | null): RsvpState {
+  const counts: RsvpCounts = { going: 0, maybe: 0, not_going: 0 };
+  const lists: RsvpLists | null = memberId
+    ? { going: [], maybe: [], not_going: [] }
+    : null;
+  let myStatus: RsvpStatus | null = null;
+
+  for (const row of rows) {
+    counts[row.status] += 1;
+    if (lists) lists[row.status].push(row.members);
+    if (row.member_id === memberId) myStatus = row.status;
+  }
+
+  if (lists) {
+    for (const status of Object.keys(lists) as RsvpStatus[]) {
+      lists[status].sort((a, b) => getDisplayName(a).localeCompare(getDisplayName(b)));
+    }
+  }
+
+  return { counts, myStatus, lists };
+}
+
+// The one write path for "member_id's status on event_id is X" — an upsert
+// on the (member_id, event_id) PK, since setting an RSVP is always "my
+// current status is X" rather than append-only. Shared by setEventRsvp and
+// createEvent's best-effort host seed, so the row shape (including the
+// updated_at audit stamp) can't drift between the two call sites.
+export async function upsertRsvp(memberId: string, eventId: number, status: RsvpStatus) {
+  return supabaseAdmin!
+    .from('rsvps')
+    .upsert(
+      {
+        member_id: memberId,
+        event_id: eventId,
+        status,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'member_id,event_id' }
+    );
+}
+
+// One round-trip per page visit (client:load island): aggregate counts for
+// everyone, plus the member's own status and the full named breakdowns only
+// when a valid session cookie is present. The counts returned here are
+// fresher than what the static build baked into the page — the island
+// renders whichever it has, falling back to the baked-in numbers if the
+// fetch fails (e.g. the rsvps table isn't deployed yet).
+export const getEventRsvps = defineAction({
+  handler: async ({ slug }: { slug: string }, context) => {
+    if (!supabaseAdmin) {
+      throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Supabase not configured' });
+    }
+
+    if (typeof slug !== 'string' || !slug) {
+      throw new ActionError({ code: 'BAD_REQUEST', message: 'Missing event slug' });
+    }
+
+    const eventId = await resolveEventId(slug);
+
+    const token = context.cookies.get('session')?.value;
+    const payload = token ? verifySessionToken(token) : null;
+    const memberId = payload?.memberId ?? null;
+
+    const rows = await fetchRsvpRows(eventId);
+    return buildRsvpState(rows, memberId);
+  },
+});
+
+export const setEventRsvp = defineAction({
+  handler: async ({ slug, status }: { slug: string; status: RsvpStatus | null }, context) => {
+    if (!supabaseAdmin) {
+      throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Supabase not configured' });
+    }
+
+    if (typeof slug !== 'string' || !slug) {
+      throw new ActionError({ code: 'BAD_REQUEST', message: 'Missing event slug' });
+    }
+    if (status !== null && !isRsvpStatus(status)) {
+      throw new ActionError({ code: 'BAD_REQUEST', message: 'Status must be one of going, maybe, not_going, or null to clear' });
+    }
+
+    const token = context.cookies.get('session')?.value;
+    const payload = token ? verifySessionToken(token) : null;
+    if (!payload) {
+      throw new ActionError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
+    }
+
+    const eventId = await resolveEventId(slug);
+
+    if (status === null) {
+      // Re-clicking your own active status clears your RSVP — there's no
+      // fourth "no status" value in the schema, you just have no row.
+      const { error } = await supabaseAdmin
+        .from('rsvps')
+        .delete()
+        .eq('member_id', payload.memberId)
+        .eq('event_id', eventId);
+
+      if (error) {
+        throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
+      }
+    } else {
+      const { error } = await upsertRsvp(payload.memberId, eventId, status);
+
+      if (error) {
+        throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: error.message });
+      }
+    }
+
+    const rows = await fetchRsvpRows(eventId);
+    return buildRsvpState(rows, payload.memberId);
+  },
+});

--- a/src/components/EventList/EventList.test.tsx
+++ b/src/components/EventList/EventList.test.tsx
@@ -37,6 +37,7 @@ function makeEvent(name: string, date: Date, locationName = "Trieste"): EventCol
     slug: name.toLowerCase().replace(/ /g, "-"),
     social: { instagram: "https://instagram.com/test" },
     meetingUrl: null,
+    rsvpCounts: { going: 0, maybe: 0, not_going: 0 },
   };
   return { id: name, data } as unknown as EventCollection;
 }
@@ -51,6 +52,7 @@ function makeOnlineEvent(name: string, date: Date): EventCollection {
     slug: name.toLowerCase().replace(/ /g, "-"),
     social: { instagram: "https://instagram.com/test" },
     meetingUrl: "https://meet.jit.si/test",
+    rsvpCounts: { going: 0, maybe: 0, not_going: 0 },
   };
   return { id: name, data } as unknown as EventCollection;
 }

--- a/src/components/EventRsvp/EventRsvp.test.tsx
+++ b/src/components/EventRsvp/EventRsvp.test.tsx
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import EventRsvp from "./EventRsvp";
+import type { RsvpCounts, RsvpLists, RsvpState } from "../../lib/rsvpTypes";
+
+const mockGetEventRsvps = vi.fn();
+const mockSetEventRsvp = vi.fn();
+
+vi.mock("astro:actions", () => ({
+  actions: {
+    getEventRsvps: (input: unknown) => mockGetEventRsvps(input),
+    setEventRsvp: (input: unknown) => mockSetEventRsvp(input),
+  },
+}));
+
+const baseCounts: RsvpCounts = { going: 2, maybe: 1, not_going: 0 };
+
+const memberLists: RsvpLists = {
+  going: [
+    { username: "alice", full_name: null, display_full_name: false },
+    { username: "bob", full_name: "Bob Smith", display_full_name: true },
+  ],
+  maybe: [{ username: "carol", full_name: null, display_full_name: false }],
+  not_going: [],
+};
+
+const memberState: RsvpState = {
+  counts: baseCounts,
+  myStatus: "going",
+  lists: memberLists,
+};
+
+beforeEach(() => {
+  mockGetEventRsvps.mockReset();
+  mockSetEventRsvp.mockReset();
+});
+
+describe("EventRsvp", () => {
+  it("shows a loading message before the action resolves, with the controls present but disabled", () => {
+    mockGetEventRsvps.mockReturnValue(new Promise(() => {}));
+    render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2099-01-01T18:00:00.000Z" />);
+
+    // Deliberate tradeoff: shows "Loading…" on every load until the fetch
+    // resolves — a no-JS visitor, a slow/failed fetch, or a crawler that
+    // doesn't wait on hydration all see this placeholder rather than a
+    // real count.
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(screen.queryByText("2 going · 1 maybe")).not.toBeInTheDocument();
+    // The RSVP buttons render immediately (no pop-in once isMember
+    // resolves) but stay disabled until then. "See all" is treated as
+    // unknown/empty until isMember resolves, so it's absent, not disabled.
+    expect(screen.getByRole("button", { name: "Going" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "See all" })).not.toBeInTheDocument();
+  });
+
+  it("shows counts and the real RSVP buttons for an anonymous visitor, with no names", async () => {
+    mockGetEventRsvps.mockResolvedValue({
+      data: { counts: baseCounts, myStatus: null, lists: null },
+    });
+
+    render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2099-01-01T18:00:00.000Z" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("2 going · 1 maybe")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Going" })).not.toBeDisabled();
+    expect(screen.queryByRole("heading", { name: "Going", level: 3 })).not.toBeInTheDocument();
+  });
+
+  it("hides the 'See all' link when no one has RSVPed yet", async () => {
+    const zeroCounts: RsvpCounts = { going: 0, maybe: 0, not_going: 0 };
+    mockGetEventRsvps.mockResolvedValue({
+      data: { counts: zeroCounts, myStatus: null, lists: null },
+    });
+
+    render(<EventRsvp slug="philosophy-101" initialCounts={zeroCounts} date="2099-01-01T18:00:00.000Z" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No responses yet.")).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: "See all" })).not.toBeInTheDocument();
+  });
+
+  it("opens the header's login modal instead of setting a status, when an anonymous visitor clicks an RSVP button", async () => {
+    mockGetEventRsvps.mockResolvedValue({
+      data: { counts: baseCounts, myStatus: null, lists: null },
+    });
+
+    // Mirrors the static trigger button LoginButton.tsx listens on
+    // (Header.astro) — an anonymous click on a real RSVP button reuses it
+    // rather than calling setEventRsvp or navigating to a login page.
+    const headerTrigger = document.createElement("button");
+    headerTrigger.id = "cnf-login-trigger";
+    const onHeaderTriggerClick = vi.fn();
+    headerTrigger.addEventListener("click", onHeaderTriggerClick);
+    document.body.appendChild(headerTrigger);
+
+    render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2099-01-01T18:00:00.000Z" />);
+
+    // The button is present from the first render but starts disabled until
+    // isMember resolves — wait for that before clicking it.
+    const goingButton = screen.getByRole("button", { name: "Going" });
+    await waitFor(() => expect(goingButton).not.toBeDisabled());
+    fireEvent.click(goingButton);
+
+    expect(onHeaderTriggerClick).toHaveBeenCalledOnce();
+    expect(mockSetEventRsvp).not.toHaveBeenCalled();
+
+    document.body.removeChild(headerTrigger);
+  });
+
+  it("shows the RSVP controls and highlights the member's own status", async () => {
+    mockGetEventRsvps.mockResolvedValue({ data: memberState });
+
+    render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2099-01-01T18:00:00.000Z" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Going", pressed: true })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: /log in/i })).not.toBeInTheDocument();
+  });
+
+  it("opens the attendee list modal, with named breakdowns, when a member clicks 'See all'", async () => {
+    mockGetEventRsvps.mockResolvedValue({ data: memberState });
+
+    render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2099-01-01T18:00:00.000Z" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Going", pressed: true })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "See all" }));
+
+    const goingHeading = screen.getByRole("heading", { name: "Going", level: 3 });
+    expect(goingHeading).toBeVisible();
+    expect(within(goingHeading.parentElement!).getByText("2")).toBeVisible();
+
+    const maybeHeading = screen.getByRole("heading", { name: "Maybe", level: 3 });
+    expect(maybeHeading).toBeVisible();
+    expect(within(maybeHeading.parentElement!).getByText("1")).toBeVisible();
+
+    expect(screen.getByText("alice")).toBeVisible();
+    expect(screen.getByText("Bob Smith")).toBeVisible();
+  });
+
+  it("opens the login modal instead of the attendee list, when an anonymous visitor clicks 'See all'", async () => {
+    mockGetEventRsvps.mockResolvedValue({
+      data: { counts: baseCounts, myStatus: null, lists: null },
+    });
+
+    const headerTrigger = document.createElement("button");
+    headerTrigger.id = "cnf-login-trigger";
+    const onHeaderTriggerClick = vi.fn();
+    headerTrigger.addEventListener("click", onHeaderTriggerClick);
+    document.body.appendChild(headerTrigger);
+
+    render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2099-01-01T18:00:00.000Z" />);
+
+    const seeAllButton = await screen.findByRole("button", { name: "See all" });
+    fireEvent.click(seeAllButton);
+
+    expect(onHeaderTriggerClick).toHaveBeenCalledOnce();
+
+    document.body.removeChild(headerTrigger);
+  });
+
+  it("sends a new status when a member changes their RSVP and refreshes from the response", async () => {
+    mockGetEventRsvps.mockResolvedValue({ data: memberState });
+    mockSetEventRsvp.mockResolvedValue({
+      data: {
+        counts: { going: 1, maybe: 2, not_going: 0 },
+        myStatus: "maybe",
+        lists: {
+          going: [memberLists.going[1]],
+          maybe: [memberLists.going[0], memberLists.maybe[0]],
+          not_going: [],
+        },
+      },
+    });
+
+    render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2099-01-01T18:00:00.000Z" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Going", pressed: true })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Maybe" }));
+
+    expect(mockSetEventRsvp).toHaveBeenCalledWith({ slug: "philosophy-101", status: "maybe" });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Maybe", pressed: true })).toBeInTheDocument();
+    });
+    expect(screen.getByText("1 going · 2 maybe")).toBeInTheDocument();
+  });
+
+  it("clears the member's RSVP when they click their own active status again", async () => {
+    mockGetEventRsvps.mockResolvedValue({ data: memberState });
+    mockSetEventRsvp.mockResolvedValue({
+      data: {
+        counts: { going: 1, maybe: 1, not_going: 0 },
+        myStatus: null,
+        lists: {
+          going: [memberLists.going[1]],
+          maybe: memberLists.maybe,
+          not_going: [],
+        },
+      },
+    });
+
+    render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2099-01-01T18:00:00.000Z" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Going", pressed: true })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Going" }));
+
+    expect(mockSetEventRsvp).toHaveBeenCalledWith({ slug: "philosophy-101", status: null });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Going", pressed: false })).toBeInTheDocument();
+    });
+    expect(screen.getByText("1 going · 1 maybe")).toBeInTheDocument();
+  });
+
+  it("shows the action error when setting an RSVP fails", async () => {
+    mockGetEventRsvps.mockResolvedValue({ data: memberState });
+    mockSetEventRsvp.mockResolvedValue({ error: { message: "Not authenticated" } });
+
+    render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2099-01-01T18:00:00.000Z" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Going", pressed: true })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Not going" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Not authenticated")).toBeInTheDocument();
+    });
+  });
+
+  it("keeps the RSVP controls off once the event has passed", async () => {
+    mockGetEventRsvps.mockResolvedValue({ data: memberState });
+
+    render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2000-01-01T18:00:00.000Z" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Going")).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: "Going" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /log in/i })).not.toBeInTheDocument();
+  });
+
+  it("falls back to the static counts if the action errors", async () => {
+    mockGetEventRsvps.mockResolvedValue({ error: { message: "Event not found" } });
+
+    render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2099-01-01T18:00:00.000Z" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("2 going · 1 maybe")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/EventRsvp/EventRsvp.tsx
+++ b/src/components/EventRsvp/EventRsvp.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useState } from "react";
+import { actions } from "astro:actions";
+import { getDisplayName } from "../../lib/memberDisplay";
+import Modal from "../Modal/Modal";
+import {
+  RSVP_LABELS,
+  RSVP_STATUSES,
+  type RsvpCounts,
+  type RsvpLists,
+  type RsvpStatus,
+} from "../../lib/rsvpTypes";
+
+// #27: the event page's attendance widget. RSVPs don't trigger a rebuild
+// (only createEvent/updateEvent do), so the build-time counts baked into
+// EventRsvpProps.initialCounts can be stale — a single getEventRsvps call on
+// hydration is what makes them trustworthy, and — for a logged-in member
+// only — brings back their own status plus the full named breakdowns.
+// Deliberate tradeoff: the summary shows "Loading…" until that call
+// resolves, on every load, so a no-JS visitor (or a crawler that doesn't
+// wait on hydration) sees that placeholder rather than a real count — chosen
+// over a silent stale-number swap for the sake of a visible "this is live"
+// loading state. Setting/clearing a status goes through setEventRsvp and
+// re-renders from its fresh state.
+export default function EventRsvp({ slug, initialCounts, date }: EventRsvpProps) {
+  const [counts, setCounts] = useState<RsvpCounts>(initialCounts);
+  const [myStatus, setMyStatus] = useState<RsvpStatus | null>(null);
+  const [lists, setLists] = useState<RsvpLists | null>(null);
+  const [isMember, setIsMember] = useState<boolean | null>(null);
+  const [setting, setSetting] = useState<RsvpStatus | null>(null);
+  const [error, setError] = useState("");
+  const [showAttendees, setShowAttendees] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  const eventHasPassed = new Date(date).getTime() < Date.now();
+
+  useEffect(() => {
+    let cancelled = false;
+    actions.getEventRsvps({ slug }).then(({ data, error: actionError }) => {
+      if (cancelled) return;
+      // Falls back to the build-time counts on error — data left untouched,
+      // isMember stays null, so the member-only controls simply don't show.
+      if (!actionError && data) {
+        setCounts(data.counts);
+        setMyStatus(data.myStatus);
+        setLists(data.lists);
+        setIsMember(data.lists !== null);
+      }
+      setLoaded(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  async function handleStatus(status: RsvpStatus) {
+    if (eventHasPassed || setting !== null) return;
+    // Clicking your own active status again clears it, rather than being a
+    // no-op — the same toggle-button behavior as Meetup/Facebook's RSVP.
+    const nextStatus = status === myStatus ? null : status;
+    setSetting(status);
+    setError("");
+    const { data, error: actionError } = await actions.setEventRsvp({ slug, status: nextStatus });
+    setSetting(null);
+    if (actionError) {
+      setError(actionError.message);
+      return;
+    }
+    if (data) {
+      setCounts(data.counts);
+      setMyStatus(data.myStatus);
+      setLists(data.lists);
+    }
+  }
+
+  // Reuses the header's existing login modal (LoginButton.tsx) rather than
+  // duplicating it — that component wires its click listener onto this exact
+  // static trigger, which is always present in the page's Header.
+  function openLoginModal() {
+    document.getElementById("cnf-login-trigger")?.click();
+  }
+
+  // The one place that decides "is this visitor allowed to do member-only
+  // things" — used by both the status buttons and "See all", so a future
+  // change to the gating condition only has one call site to update.
+  function gate(action: () => void) {
+    return () => (isMember ? action() : openLoginModal());
+  }
+
+  const total = counts.going + counts.maybe + counts.not_going;
+  const summary = [counts.going > 0 && `${counts.going} going`, counts.maybe > 0 && `${counts.maybe} maybe`, counts.not_going > 0 && `${counts.not_going} not going`]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <section aria-label="Attendance">
+      <div className="cnf-section__header">
+        <h2 className="cnf-rsvp__title">Attendance</h2>
+        {isMember !== null && total > 0 && (
+          // Not shown at all until isMember resolves — before that we treat
+          // attendance as unknown/empty rather than showing a disabled
+          // placeholder, since we don't yet know whether a click should
+          // open the attendee list or the login modal.
+          <button
+            type="button"
+            className="cnf-button cnf-button--link"
+            onClick={gate(() => setShowAttendees(true))}
+          >
+            See all
+          </button>
+        )}
+      </div>
+      <p className="cnf-rsvp__summary">
+        {loaded ? summary || (total === 0 ? "No responses yet." : "") : "Loading…"}
+      </p>
+
+      {!eventHasPassed && (
+        // Rendered from the first paint (no isMember-gated pop-in) — each
+        // button stays disabled until isMember resolves, since we don't yet
+        // know whether a click should set a status or open the login modal.
+        // Anonymous visitors see the same real buttons as members —
+        // clicking one just pops the header's login modal instead of
+        // setting a status (mirrors Meetup/Facebook: show the real
+        // action, gate it on click, rather than a separate "log in to
+        // RSVP" prompt).
+        <div className="cnf-rsvp__controls" role="group" aria-label="Your attendance">
+          {RSVP_STATUSES.map((status) => (
+            <button
+              key={status}
+              type="button"
+              className={`cnf-button cnf-button--compact cnf-rsvp__status ${myStatus === status ? "cnf-button__primary" : "cnf-button__secondary"}${setting === status ? " cnf-button--loading" : ""}`}
+              aria-pressed={myStatus === status}
+              aria-busy={setting === status}
+              disabled={isMember === null || setting !== null}
+              onClick={gate(() => handleStatus(status))}
+            >
+              <span className="cnf-button__text">{RSVP_LABELS[status]}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <p className="cnf-rsvp__error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {lists && (
+        <Modal isOpen={showAttendees} onClose={() => setShowAttendees(false)}>
+          <h2>Attendance</h2>
+          <div className="cnf-rsvp__lists">
+            {RSVP_STATUSES.map((status) =>
+              lists[status].length > 0 ? (
+                <div key={status} className="cnf-rsvp__list">
+                  <div className="cnf-rsvp__list-header">
+                    <h3 className="cnf-rsvp__list-title">{RSVP_LABELS[status]}</h3>
+                    <span className="cnf-count" aria-hidden="true">{lists[status].length}</span>
+                  </div>
+                  <ul className="cnf-rsvp__list-members">
+                    {lists[status].map((member) => (
+                      <li key={member.username}>
+                        <a href={`/profile/${member.username}`}>{getDisplayName(member)}</a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null
+            )}
+          </div>
+        </Modal>
+      )}
+    </section>
+  );
+}
+
+type EventRsvpProps = {
+  slug: string;
+  initialCounts: RsvpCounts;
+  date: string;
+};

--- a/src/components/SuggestTopicForm.tsx
+++ b/src/components/SuggestTopicForm.tsx
@@ -64,7 +64,7 @@ export default function TopicSuggestForm() {
   function renderTopics() {
     return (
       <div aria-live="polite">
-        <span className="cnf-suggest__count" aria-hidden="true">{topics.length}</span> Suggested
+        <span className="cnf-count" aria-hidden="true">{topics.length}</span> Suggested
         topic{topics.length !== 1 ? "s" : ""}:
         <ul className="cnf-suggest__list" aria-label="Suggested topics">
           {topics.map((topic: string, key: number) => (

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -43,6 +43,11 @@ const event = defineCollection({
     }),
     meetingUrl: z.string().nullable(),
     creator: memberRefSchema,
+    rsvpCounts: z.object({
+      going: z.number(),
+      maybe: z.number(),
+      not_going: z.number(),
+    }),
   }),
 });
 

--- a/src/lib/rsvpTypes.ts
+++ b/src/lib/rsvpTypes.ts
@@ -1,0 +1,46 @@
+// Shared RSVP domain types + constants, imported by the server actions
+// (src/actions/rsvps.ts), the content loader's per-event counts, and the
+// client-side EventRsvp island. Kept free of any Supabase/auth imports so it
+// can be pulled into a React client bundle without dragging server code in.
+
+export const RSVP_STATUSES = ["going", "maybe", "not_going"] as const;
+
+export type RsvpStatus = (typeof RSVP_STATUSES)[number];
+
+export type RsvpCounts = {
+  going: number;
+  maybe: number;
+  not_going: number;
+};
+
+export type RsvpMember = {
+  username: string;
+  full_name: string | null;
+  display_full_name: boolean;
+};
+
+export type RsvpLists = {
+  going: RsvpMember[];
+  maybe: RsvpMember[];
+  not_going: RsvpMember[];
+};
+
+// The full page-level state returned by both RSVP server actions. `lists`
+// (and therefore `myStatus`) are only populated for an authenticated member —
+// a public visitor gets aggregate `counts` and nothing that could identify
+// who's on them.
+export type RsvpState = {
+  counts: RsvpCounts;
+  myStatus: RsvpStatus | null;
+  lists: RsvpLists | null;
+};
+
+export const RSVP_LABELS: Record<RsvpStatus, string> = {
+  going: "Going",
+  maybe: "Maybe",
+  not_going: "Not going",
+};
+
+export function isRsvpStatus(value: unknown): value is RsvpStatus {
+  return typeof value === "string" && (RSVP_STATUSES as readonly string[]).includes(value);
+}

--- a/src/loaders/events.ts
+++ b/src/loaders/events.ts
@@ -2,6 +2,7 @@ import type { Loader } from 'astro/loaders';
 import { supabaseAdmin } from '../lib/supabase';
 import { unwrapRelation } from '../lib/supabaseRelations';
 import { getAllClubs } from '../lib/clubs';
+import { isRsvpStatus, type RsvpCounts } from '../lib/rsvpTypes';
 
 export function eventsLoader(): Loader {
   return {
@@ -13,16 +14,35 @@ export function eventsLoader(): Loader {
 
       store.clear();
 
-      const [eventsResult, clubs] = await Promise.all([
+      const [eventsResult, clubs, rsvpsResult] = await Promise.all([
         supabaseAdmin
           .from('events')
-          .select('*, venues(name, url), members(username, full_name, display_full_name)')
+          .select('*, venues(name, url), members!events_created_by_fkey(username, full_name, display_full_name)')
           .order('date', { ascending: true }),
         getAllClubs(),
+        supabaseAdmin.from('rsvps').select('event_id, status'),
       ]);
 
       if (eventsResult.error) {
         throw new Error(`Failed to fetch events from Supabase: ${eventsResult.error.message}`);
+      }
+
+      // #27: build-time aggregate RSVP counts, baked into each event page so
+      // a no-JS visitor (and the initial paint) still sees "12 going, 3
+      // maybe". Tolerated rather than fatal when the rsvps table isn't
+      // deployed yet — a migration-pending build shouldn't take the whole
+      // site down, and the client-side island refreshes live counts once the
+      // table exists.
+      const rsvpCountsByEvent = new Map<number, RsvpCounts>();
+      if (rsvpsResult.error) {
+        console.error(`Failed to fetch RSVP counts from Supabase: ${rsvpsResult.error.message}`);
+      } else {
+        for (const row of rsvpsResult.data ?? []) {
+          if (!isRsvpStatus(row.status)) continue;
+          const counts = rsvpCountsByEvent.get(row.event_id) ?? { going: 0, maybe: 0, not_going: 0 };
+          counts[row.status] += 1;
+          rsvpCountsByEvent.set(row.event_id, counts);
+        }
       }
 
       const clubsMap = new Map(clubs.map((c) => [c.id, c]));
@@ -76,6 +96,7 @@ export function eventsLoader(): Loader {
             },
             meetingUrl: event.meeting_url,
             creator,
+            rsvpCounts: rsvpCountsByEvent.get(event.id) ?? { going: 0, maybe: 0, not_going: 0 },
           },
         });
       }

--- a/src/pages/[clubSlug]/events/[eventSlug].astro
+++ b/src/pages/[clubSlug]/events/[eventSlug].astro
@@ -5,6 +5,7 @@ import { formatEventDate } from "../../../utils/script";
 import "../../../styles/event.css";
 import { getCollection } from "astro:content";
 import Banner from "../../../layouts/Banner.astro";
+import EventRsvp from "../../../components/EventRsvp/EventRsvp";
 import { getDisplayName } from "../../../lib/memberDisplay";
 import { getAllClubs, clubSlugsForEvent } from "../../../lib/clubs";
 import { DEFAULT_CLUB_SLUG } from "../../../lib/clubDefaults";
@@ -73,7 +74,24 @@ const canonicalPath = event.data.location
         <p>{event.data.summary}</p>
       </div>
     )}
-    {(event.data.social.instagram || event.data.social.facebook || event.data.social.meetup) && (
+    <div class="cnf-event-page__details">
+      <span class="cnf-event-page__details-info"
+        >Hosted by <a href={`/profile/${event.data.creator.username}`}>{getDisplayName(event.data.creator)}</a></span
+      >
+    </div>
+  </section>
+
+  <section class="cnf-section">
+    <EventRsvp
+      slug={event.data.slug}
+      initialCounts={event.data.rsvpCounts}
+      date={event.data.date.toISOString()}
+      client:load
+    />
+  </section>
+
+  {(event.data.social.instagram || event.data.social.facebook || event.data.social.meetup) && (
+    <section class="cnf-section">
       <div class="cnf-event-page__social">
         <h2>Social links</h2>
         <ul>
@@ -121,13 +139,8 @@ const canonicalPath = event.data.location
           }
         </ul>
       </div>
-    )}
-    <div class="cnf-event-page__details">
-      <span class="cnf-event-page__details-info"
-        >Hosted by <a href={`/profile/${event.data.creator.username}`}>{getDisplayName(event.data.creator)}</a></span
-      >
-    </div>
-  </section>
+    </section>
+  )}
   <Banner
     title="Like to suggest a topic?"
     description="Why not help the never-ending list of topics grow even more!"

--- a/src/styles/event.css
+++ b/src/styles/event.css
@@ -147,6 +147,56 @@
   gap: 0.5rem;
 }
 
+.cnf-rsvp__title {
+  margin: 0 0 0.5rem;
+}
+
+.cnf-rsvp__summary {
+  margin: 0 0 1rem;
+}
+
+.cnf-rsvp__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.cnf-rsvp__status:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.cnf-rsvp__error {
+  margin: 0 0 1rem;
+  color: hsl(var(--color-red));
+}
+
+.cnf-rsvp__lists {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* The count sits next to the heading, not inside it — otherwise it inherits
+   the heading's Playfair/weight/color and needs overriding back to plain
+   body text. */
+.cnf-rsvp__list-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin: 0 0 0.25rem;
+}
+
+.cnf-rsvp__list-title {
+  margin: 0;
+}
+
+.cnf-rsvp__list-members {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
 @media (min-width: 576px) {
   .cnf-events--grid {
     grid-template-columns: repeat(2, 1fr);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -280,6 +280,16 @@ blockquote {
   text-align: center;
 }
 
+/* Small pill badge for a count next to a label (e.g. "Going 2") — shared
+   across the site rather than owned by any one feature; originally the
+   suggest-topic count, generalized for reuse. */
+.cnf-count {
+  background-color: hsl(var(--color-white));
+  padding: 0.2rem 0.5rem;
+  color: hsl(var(--color-green));
+  border-radius: 50px;
+}
+
 .cnf-button {
   position: relative;
   padding: 1rem 1.5rem;
@@ -295,6 +305,16 @@ blockquote {
 
 .cnf-button--compact {
   padding: 0.5rem 1rem;
+}
+
+/* Reads as a plain text link (matches the real <a> styling above) rather
+   than a button — for actions that need a click handler instead of an href. */
+.cnf-button--link {
+  background-color: transparent;
+  padding: 0;
+  color: hsl(var(--color-green));
+  font-weight: inherit;
+  text-decoration: underline;
 }
 
 .cnf-button__primary {
@@ -353,6 +373,13 @@ blockquote {
   border-top-color: hsl(var(--color-white));
   border-radius: 50%;
   animation: button-loading-spinner 1s ease infinite;
+}
+
+/* .cnf-button__secondary's background is light (beige) — the default white
+   spinner is barely visible on it, unlike on the dark primary/gold buttons
+   it was designed for. */
+.cnf-button__secondary.cnf-button--loading::after {
+  border-top-color: hsl(var(--color-green));
 }
 
 .cnf-button:active {

--- a/src/styles/suggest-topic.css
+++ b/src/styles/suggest-topic.css
@@ -21,13 +21,6 @@
   padding: 5px 0;
 }
 
-.cnf-suggest__count {
-  background-color: hsl(var(--color-white));
-  padding: 0.2rem 0.5rem;
-  color: hsl(var(--color-green));
-  border-radius: 50px;
-}
-
 .cnf-suggest__icon {
   width: 1rem;
   height: 1rem;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -22,6 +22,11 @@ export type Event = {
     meetup?: string | null;
   };
   meetingUrl: string | null;
+  rsvpCounts: {
+    going: number;
+    maybe: number;
+    not_going: number;
+  };
 };
 
 export interface BannerProps {

--- a/src/utils/script.test.ts
+++ b/src/utils/script.test.ts
@@ -33,6 +33,7 @@ describe("isEventExpired", () => {
       venue: { name: "Test Venue", url: "https://test.com" },
       social: { instagram: "https://instagram.com" },
       meetingUrl: null,
+      rsvpCounts: { going: 0, maybe: 0, not_going: 0 },
     };
     expect(isEventExpired(pastEvent)).toBe(true);
   });
@@ -47,6 +48,7 @@ describe("isEventExpired", () => {
       venue: { name: "Test Venue", url: "https://test.com" },
       social: { instagram: "https://instagram.com" },
       meetingUrl: null,
+      rsvpCounts: { going: 0, maybe: 0, not_going: 0 },
     };
     expect(isEventExpired(futureEvent)).toBe(false);
   });

--- a/supabase/migrations/20260829120000_add_rsvps.sql
+++ b/supabase/migrations/20260829120000_add_rsvps.sql
@@ -1,0 +1,24 @@
+-- Issue #27: RSVP for event availability.
+--
+-- A member declares their expected attendance at a specific event. One row
+-- per (member, event): a member revisiting the event page changes their own
+-- status in place rather than stacking duplicate rows.
+--
+-- `status` is restricted to the three states the public page can render
+-- ("going", "maybe", "not going"); the CHECK constraint keeps a bad write
+-- (from a stale client or a future refactor) from ever landing. `updated_at`
+-- is the last time the status was set/changed — used for auditing and to
+-- surface "most recent RSVPs" if that ever becomes a list feature.
+create table public.rsvps (
+  member_id  uuid    not null references public.members(id) on delete cascade,
+  event_id   integer not null references public.events(id) on delete cascade,
+  status     text    not null check (status in ('going', 'maybe', 'not_going')),
+  updated_at timestamp with time zone default now(),
+  primary key (member_id, event_id)
+);
+
+-- Lookups for a single event's RSVPs (the event page and both RSVP actions)
+-- filter on event_id alone, which the composite PK can't serve.
+create index rsvps_event_id_idx on public.rsvps (event_id);
+
+alter table public.rsvps enable row level security;


### PR DESCRIPTION
Closes #27.

### Why

Members can't indicate whether they're attending an upcoming event, so there's no read on expected turnout ahead of time. This adds an RSVP: a member marks **Going / Maybe / Not going** for a specific event, non-members see an aggregate count per status on the public event page (no names), and logged-in members see the full named list broken down by status and can change their own answer on revisit.

### How it was achieved

- **Schema** — new `rsvps` table (`supabase/migrations/20260829120000_add_rsvps.sql`): composite PK `(member_id, event_id)`, `status` CHECK-constrained to `('going','maybe','not_going')`, `updated_at` audit stamp, `ON DELETE CASCADE` on both FKs, index on `event_id`, and row-level security enabled. One row per (member, event) — revisiting changes in place, never stacks duplicates.
- **Server actions** (`src/actions/rsvps.ts`, registered in `src/actions/index.ts`):
  - `getEventRsvps` — resolves the event by slug (400 on unknown), reads the session cookie, and returns aggregate `counts` for everyone plus `myStatus`/named `lists` **only** when authenticated, so a public visitor never learns who rsvp'd.
  - `setEventRsvp` — requires an authenticated session, upserts on the `(member_id, event_id)` PK with a fresh `updated_at`, then returns the rebuilt state.
- **Client island** (`src/components/EventRsvp/EventRsvp.tsx` + tests) — the event page's Attendance widget. Static build bakes aggregate counts into the page (no-JS visitors still see "12 going · 3 maybe"); on hydration one `getEventRsvps` call refreshes counts and, for members only, the named breakdowns. Setting a status goes through `setEventRsvp` and re-renders from the fresh state. Passed events don't accept new RSVPs.
- **Build-time counts** (`src/loaders/events.ts`) — the events loader fetches all rsvps alongside events and bakes per-event aggregate counts in, tolerating a not-yet-deployed `rsvps` table (logs and continues) rather than taking the site down; the island refreshes live counts once the table exists.
- **Shared types** (`src/lib/rsvpTypes.ts`) — domain types/constants kept free of Supabase/auth imports so the React bundle never drags in server code. Event content schema extended with `rsvpCounts` (`src/content.config.ts`).
- **Wiring/styles** — event detail page renders the island (baked `rsvpCounts` passed in, `src/pages/[clubSlug]/events/[eventSlug].astro`, `src/types/types.ts`); styles in `src/styles/event.css`. Existing `EventList`/`script` tests adjusted for the new loader shape.

### Concerns & Comments

- Diagnostics gate green: `npx tsc --noEmit` clean, `npx @astrojs/check` 0 errors / 0 warnings, `npm test` 135 passed across 19 files, `npm run build` succeeds (Netlify SSR).
- Live RSVP counts depend on the migration being applied to Supabase (`20260829120000_add_rsvps.sql`). Until it's deployed, the site keeps working with zeroed/baked counts and the island silently falls back to them.
- FKs reference `members`/`events` with `ON DELETE CASCADE`, so a deleted member's RSVPs are cleaned up automatically.