### PR TITLE
Add club + online/in-person filtering to events page

### DIFF
--- a/src/components/EventList/EventList.test.tsx
+++ b/src/components/EventList/EventList.test.tsx
@@ -25,13 +25,15 @@ vi.mock("../../layouts/EventCard", () => ({
 vi.mock("../../styles/event.css", () => ({}));
 
 // `data` is typed as the real `Event` shape (not the loosely-cast wrapper
-// below) so a future field added there — like the #39 `location.slug` — is
-// enforced here too, instead of being silently absent from these fixtures.
+// below) so a future field added there — like the #39 `location.slug` or the
+// #52 `club` — is enforced here too, instead of being silently absent from
+// these fixtures.
 function makeEvent(name: string, date: Date, locationName = "Trieste"): EventCollection {
   const data: Event = {
     name,
     date,
     location: { id: 1, name: locationName, slug: locationName.toLowerCase() },
+    club: { id: 1, name: locationName, slug: locationName.toLowerCase() },
     isOnline: false,
     venue: { name: "Test Venue", url: "https://maps.google.com" },
     slug: name.toLowerCase().replace(/ /g, "-"),
@@ -41,11 +43,14 @@ function makeEvent(name: string, date: Date, locationName = "Trieste"): EventCol
   return { id: name, data } as unknown as EventCollection;
 }
 
-function makeOnlineEvent(name: string, date: Date): EventCollection {
+function makeOnlineEvent(name: string, date: Date, clubName: string | null = null): EventCollection {
   const data: Event = {
     name,
     date,
     location: null,
+    club: clubName
+      ? { id: 2, name: clubName, slug: clubName.toLowerCase() }
+      : null,
     isOnline: true,
     venue: null,
     slug: name.toLowerCase().replace(/ /g, "-"),
@@ -57,9 +62,29 @@ function makeOnlineEvent(name: string, date: Date): EventCollection {
 
 const futureDate1 = new Date("2099-01-01");
 const futureDate2 = new Date("2099-06-01");
+const futureDate3 = new Date("2099-09-01");
 const pastDate1 = new Date("2020-01-01");
 const pastDate2 = new Date("2021-06-01");
 const pastDate3 = new Date("2019-03-01");
+
+// The sub-filter (Format) selector is present whenever a specific club is
+// selected; the location selector is the one whose options never include the
+// "All" format sentinel.
+function getLocationSelect(): HTMLSelectElement {
+  const location = screen.getAllByRole("combobox").find(
+    (s) => !Array.from(s.querySelectorAll("option")).some((o) => o.value === "All")
+  );
+  expect(location).toBeDefined();
+  return location as HTMLSelectElement;
+}
+
+function getFormatSelect(): HTMLSelectElement {
+  const format = screen.getAllByRole("combobox").find(
+    (s) => Array.from(s.querySelectorAll("option")).some((o) => o.value === "All")
+  );
+  expect(format).toBeDefined();
+  return format as HTMLSelectElement;
+}
 
 describe("EventList", () => {
   describe("upcoming events", () => {
@@ -127,9 +152,103 @@ describe("EventList", () => {
         makeOnlineEvent("Online Event", futureDate2),
       ];
       render(<EventList events={events} />);
-      fireEvent.change(screen.getByRole("combobox"), { target: { value: "Online" } });
+      fireEvent.change(getLocationSelect(), { target: { value: "Online" } });
       expect(screen.getAllByTestId("upcoming-event")).toHaveLength(1);
       expect(screen.getByText("Online Event")).toBeInTheDocument();
+    });
+  });
+
+  describe("cross-chapter Online view", () => {
+    it("shows every online event across all clubs", () => {
+      const events = [
+        makeEvent("Trieste In-Person", futureDate1, "Trieste"),
+        makeOnlineEvent("Trieste Online", futureDate2, "Trieste"),
+        makeOnlineEvent("Dublin Online", futureDate2, "Dublin"),
+        makeOnlineEvent("Global Online", futureDate3),
+      ];
+      render(<EventList events={events} />);
+      fireEvent.change(getLocationSelect(), { target: { value: "Online" } });
+      const cards = screen.getAllByTestId("upcoming-event");
+      expect(cards).toHaveLength(3);
+      expect(screen.getByText("Trieste Online")).toBeInTheDocument();
+      expect(screen.getByText("Dublin Online")).toBeInTheDocument();
+      expect(screen.getByText("Global Online")).toBeInTheDocument();
+      expect(screen.queryByText("Trieste In-Person")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("per-club format filter", () => {
+    it("exposes an in-person/online filter when a specific club is selected", () => {
+      const events = [
+        makeEvent("Trieste In-Person", futureDate1, "Trieste"),
+        makeOnlineEvent("Trieste Online", futureDate2, "Trieste"),
+      ];
+      render(<EventList events={events} />);
+      expect(getFormatSelect()).toBeInTheDocument();
+    });
+
+    it("hides the format filter while the cross-chapter Online entry is selected", () => {
+      const events = [makeOnlineEvent("Global Online", futureDate1)];
+      render(<EventList events={events} />);
+      expect(screen.getAllByRole("combobox")).toHaveLength(1);
+    });
+
+    it("shows only the selected club's online events under club > Online", () => {
+      const events = [
+        makeEvent("Trieste In-Person", futureDate1, "Trieste"),
+        makeOnlineEvent("Trieste Online", futureDate2, "Trieste"),
+        makeOnlineEvent("Dublin Online", futureDate3, "Dublin"),
+        makeOnlineEvent("Global Online", futureDate3),
+      ];
+      render(<EventList events={events} />);
+      fireEvent.change(getLocationSelect(), { target: { value: "Trieste" } });
+      fireEvent.change(getFormatSelect(), { target: { value: "Online" } });
+      const cards = screen.getAllByTestId("upcoming-event");
+      expect(cards).toHaveLength(1);
+      expect(screen.getByText("Trieste Online")).toBeInTheDocument();
+      expect(screen.queryByText("Trieste In-Person")).not.toBeInTheDocument();
+      expect(screen.queryByText("Dublin Online")).not.toBeInTheDocument();
+      expect(screen.queryByText("Global Online")).not.toBeInTheDocument();
+    });
+
+    it("shows in-person and online together under club > All", () => {
+      const events = [
+        makeEvent("Trieste In-Person", futureDate1, "Trieste"),
+        makeOnlineEvent("Trieste Online", futureDate2, "Trieste"),
+      ];
+      render(<EventList events={events} />);
+      fireEvent.change(getLocationSelect(), { target: { value: "Trieste" } });
+      expect(screen.getAllByTestId("upcoming-event")).toHaveLength(2);
+      expect(screen.getByText("Trieste In-Person")).toBeInTheDocument();
+      expect(screen.getByText("Trieste Online")).toBeInTheDocument();
+    });
+
+    it("shows only in-person events under club > In-person", () => {
+      const events = [
+        makeEvent("Trieste In-Person", futureDate1, "Trieste"),
+        makeOnlineEvent("Trieste Online", futureDate2, "Trieste"),
+      ];
+      render(<EventList events={events} />);
+      fireEvent.change(getLocationSelect(), { target: { value: "Trieste" } });
+      fireEvent.change(getFormatSelect(), { target: { value: "In-person" } });
+      const cards = screen.getAllByTestId("upcoming-event");
+      expect(cards).toHaveLength(1);
+      expect(screen.getByText("Trieste In-Person")).toBeInTheDocument();
+      expect(screen.queryByText("Trieste Online")).not.toBeInTheDocument();
+    });
+
+    it("includes a club's online events in its past view", () => {
+      const events = [
+        makeEvent("Trieste Old In-Person", pastDate1, "Trieste"),
+        makeOnlineEvent("Trieste Old Online", pastDate2, "Trieste"),
+      ];
+      render(<EventList events={events} />);
+      fireEvent.change(getLocationSelect(), { target: { value: "Trieste" } });
+      fireEvent.click(screen.getByText("Past"));
+      const cards = screen.getAllByTestId("past-event");
+      expect(cards).toHaveLength(2);
+      expect(screen.getByText("Trieste Old In-Person")).toBeInTheDocument();
+      expect(screen.getByText("Trieste Old Online")).toBeInTheDocument();
     });
   });
 });

--- a/src/components/EventList/EventList.tsx
+++ b/src/components/EventList/EventList.tsx
@@ -1,8 +1,7 @@
 import { useState, type JSX } from "react";
 import UpcomingEvent from "../UpcomingEvent";
-import { isEventExpired } from "../../utils/script";
+import { isEventExpired, formatBlogDate } from "../../utils/script";
 import EventCard from "../../layouts/EventCard";
-import { formatBlogDate } from "../../utils/script";
 import Selector from "../Selector/Selector";
 import type { EventCollection } from "../../types/types";
 
@@ -21,11 +20,30 @@ export default function EventList(props: EventListProps) {
     ? "Online"
     : (nextUpcoming?.data.location?.name ?? locationNames[0] ?? "");
   const [selectedLocation, setSelectedLocation] = useState<string>(defaultLocation);
+  const [selectedFormat, setSelectedFormat] = useState<EventFormat>("All");
 
-  const onlineEvents = props.events.filter((e) => e.data.isOnline);
-  const locationEvents = selectedLocation === "Online"
-    ? onlineEvents
-    : props.events.filter((e) => e.data.location?.name === selectedLocation);
+  // #52: the top-level "Online" entry is the cross-chapter view — every
+  // online event in this list, regardless of which club organizes it (each
+  // card shows its hosting club). A selected club instead narrows to that
+  // club's own events — in-person (its venue's club) and hosted-online
+  // (club_id) — with an in-person/online sub-filter over just those.
+  const isClubSelected = selectedLocation !== "Online";
+  const inSelectedClub = (event: EventCollection) =>
+    event.data.club?.name === selectedLocation ||
+    event.data.location?.name === selectedLocation;
+
+  const locationEvents =
+    selectedLocation === "Online"
+      ? props.events.filter((e) => e.data.isOnline)
+      : props.events.filter(
+          (event) =>
+            inSelectedClub(event) &&
+            (selectedFormat === "All"
+              ? true
+              : selectedFormat === "Online"
+                ? event.data.isOnline
+                : !event.data.isOnline)
+        );
 
   const upcomingEvents = locationEvents.filter(
     (event) => !isEventExpired(event.data)
@@ -39,7 +57,21 @@ export default function EventList(props: EventListProps) {
       <Selector
         options={locationNames}
         value={selectedLocation}
-        onChange={setSelectedLocation}
+        onChange={(value) => {
+          setSelectedLocation(value);
+          setSelectedFormat("All");
+        }}
+      />
+    );
+  }
+
+  function renderFormatSelector(): JSX.Element {
+    return (
+      <Selector
+        label="Format"
+        options={FORMAT_OPTIONS}
+        value={selectedFormat}
+        onChange={(value) => setSelectedFormat(value as EventFormat)}
       />
     );
   }
@@ -93,11 +125,19 @@ export default function EventList(props: EventListProps) {
   return (
     <>
       {renderLocationSelector()}
+      {isClubSelected && renderFormatSelector()}
       {renderNavigation()}
       {renderEvents()}
     </>
   );
 }
+
+// #52: per-club sub-filter shown once a specific club is selected — splits
+// that club's events into in-person and online, distinct from the top-level
+// cross-chapter "Online" entry.
+type EventFormat = "All" | "In-person" | "Online";
+
+const FORMAT_OPTIONS: EventFormat[] = ["All", "In-person", "Online"];
 
 type EventListProps = {
   events: EventCollection[];

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -28,6 +28,14 @@ const event = defineCollection({
       name: z.string(),
       slug: z.string(),
     }).nullable(),
+    // #52: the hosting chapter (events.club_id) — kept separate from
+    // `location` so online events can stay "global" for routing while still
+    // surfacing their organizing club (see loaders/events.ts).
+    club: z.object({
+      id: z.number(),
+      name: z.string(),
+      slug: z.string(),
+    }).nullable(),
     isOnline: z.boolean(),
     venue: z.object({
       name: z.string().nullable(),

--- a/src/layouts/EventCard.test.tsx
+++ b/src/layouts/EventCard.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import EventCard from "./EventCard";
+import type { Event } from "../types/types";
+
+vi.mock("../styles/event.css", () => ({}));
+
+function baseEvent(overrides: Partial<Event>): Event {
+  return {
+    name: "Test Event",
+    date: new Date("2099-01-01"),
+    location: { id: 1, name: "Trieste", slug: "trieste" },
+    club: { id: 1, name: "Trieste", slug: "trieste" },
+    isOnline: false,
+    venue: { name: "Test Venue", url: "https://maps.google.com" },
+    slug: "test-event",
+    social: { instagram: "https://instagram.com/test" },
+    meetingUrl: null,
+    ...overrides,
+  };
+}
+
+describe("EventCard", () => {
+  describe("hosting club label (#52)", () => {
+    it("shows the hosting club for an online event organized by a club", () => {
+      render(<EventCard event={baseEvent({ isOnline: true, club: { id: 2, name: "Dublin", slug: "dublin" } })} />);
+      expect(screen.getByText("Hosted by CNF Dublin")).toBeInTheDocument();
+    });
+
+    it("shows a generic label for an online global (club_id null) event", () => {
+      render(<EventCard event={baseEvent({ isOnline: true, club: null })} />);
+      expect(screen.getByText("Hosted by Club na Fealsúnachta")).toBeInTheDocument();
+    });
+
+    it("leaves in-person events to their venue line", () => {
+      render(<EventCard event={baseEvent({ isOnline: false })} />);
+      expect(screen.getByText("Test Venue")).toBeInTheDocument();
+      expect(screen.queryByText(/hosted by/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/layouts/EventCard.tsx
+++ b/src/layouts/EventCard.tsx
@@ -1,5 +1,5 @@
 import type { Event } from "../types/types";
-import { formatEventDate } from "../utils/script";
+import { formatEventDate, formatClubName } from "../utils/script";
 import { DEFAULT_CLUB_SLUG } from "../lib/clubDefaults";
 
 export default function EventCard({
@@ -38,6 +38,16 @@ export default function EventCard({
                     : null
               }
             </li>
+            {/* #52: an online event has no venue line saying where it is, so
+                the organizing chapter gets its own line here — its club in
+                the cross-chapter "Online" view, a generic fallback for a
+                genuinely global (club_id null) event. In-person events are
+                already identified by their venue, so they're left alone. */}
+            {event.isOnline && (
+              <li className="cnf-event__club">
+                Hosted by {formatClubName(event.club?.name ?? null)}
+              </li>
+            )}
           </ul>
         </div>
         <div className="cnf-event__social">

--- a/src/loaders/events.ts
+++ b/src/loaders/events.ts
@@ -36,21 +36,25 @@ export function eventsLoader(): Loader {
         // genuinely cross-chapter/global. No need to derive it from the
         // venue relation separately.
         //
-        // #60: online events are always treated as global on the public
-        // site regardless of club_id — an online event isn't tied to a
-        // physical place, so it reuses the same "location: null is visible
-        // on every chapter" plumbing #39 built for genuinely cross-chapter
-        // events (clubSlugsForEvent, canonical URLs, etc.), rather than only
+        // #60: online events are treated as global on the public site
+        // regardless of club_id — an online event isn't tied to a physical
+        // place, so it reuses the same "location: null is visible on every
+        // chapter" plumbing #39 built for genuinely cross-chapter events
+        // (clubSlugsForEvent, canonical URLs, etc.), rather than only
         // showing up under whichever single chapter organizes it. club_id
         // itself is left untouched in the DB for admin/internal purposes —
-        // only this public-facing `location` is forced null. This is a
-        // temporary simplification pending #52's per-chapter online filter;
-        // revisit once that ships.
+        // only this public-facing `location` is forced null.
+        //
+        // #52: the hosting club is still surfaced separately (below) so a
+        // card can say "Hosted by CNF Dublin" and the events page can offer
+        // a per-club online filter, while the cross-chapter "Online" view
+        // keeps every online event in reach.
         const location = event.is_online
           ? null
           : event.club_id
             ? clubsMap.get(event.club_id) ?? null
             : null;
+        const club = event.club_id ? clubsMap.get(event.club_id) ?? null : null;
         const creator = unwrapRelation(event.members);
 
         if (!creator) {
@@ -64,6 +68,7 @@ export function eventsLoader(): Loader {
             name: event.name,
             date: new Date(event.date),
             location,
+            club,
             isOnline: event.is_online,
             venue: venue ? { name: venue.name, url: venue.url } : null,
             slug: event.slug,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -10,6 +10,15 @@ export type Event = {
     name: string;
     slug: string;
   } | null;
+  // Issue #52: the hosting chapter (events.club_id), exposed separately
+  // from `location` because online events keep `location` null to stay
+  // "visible on every chapter" (see #60) yet still need their organizing
+  // club surfaced on cards and in the per-club online filter.
+  club: {
+    id: number;
+    name: string;
+    slug: string;
+  } | null;
   isOnline: boolean;
   venue: {
     name: string | null;

--- a/src/utils/script.test.ts
+++ b/src/utils/script.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isValidEmail, isEventExpired, formatBlogDate } from "./script.ts";
+import { isValidEmail, isEventExpired, formatBlogDate, formatClubName } from "./script.ts";
 import type { Event } from "../types/types.ts";
 
 describe("isValidEmail", () => {
@@ -29,6 +29,7 @@ describe("isEventExpired", () => {
       name: "Test",
       date: new Date("2020-01-01"),
       location: { id: 1, name: "Trieste", slug: "trieste" },
+      club: { id: 1, name: "Trieste", slug: "trieste" },
       isOnline: false,
       venue: { name: "Test Venue", url: "https://test.com" },
       social: { instagram: "https://instagram.com" },
@@ -43,6 +44,7 @@ describe("isEventExpired", () => {
       name: "Test",
       date: new Date("2099-12-31"),
       location: { id: 1, name: "Trieste", slug: "trieste" },
+      club: { id: 1, name: "Trieste", slug: "trieste" },
       isOnline: false,
       venue: { name: "Test Venue", url: "https://test.com" },
       social: { instagram: "https://instagram.com" },
@@ -56,5 +58,16 @@ describe("formatBlogDate", () => {
   it("formats date correctly", () => {
     const result = formatBlogDate(new Date("2025-09-04"));
     expect(result).toBe("Sep 4, 2025");
+  });
+});
+
+describe("formatClubName", () => {
+  it("derives the CNF display name from the club's city name", () => {
+    expect(formatClubName("Trieste")).toBe("CNF Trieste");
+    expect(formatClubName("Dublin")).toBe("CNF Dublin");
+  });
+
+  it("falls back to the parent org for a null (global) club", () => {
+    expect(formatClubName(null)).toBe("Club na Fealsúnachta");
   });
 });

--- a/src/utils/script.ts
+++ b/src/utils/script.ts
@@ -20,6 +20,15 @@ export function isEventExpired(event: Event | null) {
   return event ? new Date(event.date) < new Date() : true;
 }
 
+// #52: display name for an event's hosting chapter. Clubs only store the
+// city name (see 20260819140000_merge_cities_into_clubs.sql — "display stays
+// derived as `CNF ${clubs.name}`"), so the derived form goes here. A null
+// name means a genuinely cross-chapter/global event with no chapter of its
+// own, which falls back to the parent org.
+export function formatClubName(name: string | null): string {
+  return name ? `CNF ${name}` : "Club na Fealsúnachta";
+}
+
 export function isValidEmail(email: string) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }


### PR DESCRIPTION
Closes #52.

### Why

Today every online event is lumped under a single "Online" entry with no indication of who organizes it, and a selected club shows all of that club's events with no in-person/online split. This PR:

- keeps the top-level selector (clubs + "Online" sibling), where "Online" remains the cross-chapter view — every online event, **each card now showing its hosting club** (e.g. "Hosted by CNF Trieste"), or a generic fallback for a genuinely global (`club_id = null`) event;
- adds a per-club **in-person/online sub-filter** once a specific club is selected — e.g. "Trieste → Online" shows just Trieste's online events, distinct from the cross-chapter "Online" entry.

This is the direct follow-up #60's PR (#61) explicitly deferred to: "Not a reversal of #52… worth revisiting once that ships."

### How it was achieved

- **Hosting club on cards** (`src/layouts/EventCard.tsx`) — online events (which have no venue line) now render `Hosted by {formatClubName(club)}`. `formatClubName` (`src/utils/script.ts`) derives the display name as `CNF ${name}` (matching the `display stays derived` convention from the cities→clubs merge) and falls back to "Club na Fealsúnachta" for genuinely global events.
- **The sub-filter** (`src/components/EventList/EventList.tsx`) — new `selectedFormat` state (`All` / `In-person` / `Online`) rendered as a "Format" selector **only when a club is selected**; selecting a club resets it. A club's events match by host club *or* venue's club so both its in-person (venue) and hosted-online (`club_id`) events land under it. The top-level "Online" entry is untouched — still every online event across chapters.
- **Expose `club` separately from `location`** — `src/loaders/events.ts` now surfaces `event.club` (derived from `events.club_id`) alongside `location`, which #60 deliberately forces `null` for online events. Keeping them separate lets an online event stay global for routing/canonical-URL plumbing while its organizing chapter is still shown on the card. `src/content.config.ts` and `src/types/types.ts` carry the new nullable `club` field.
- **Tests** — `EventList.test.tsx` extended for the new filtering behavior, new `EventCard.test.tsx` for the hosting-club line + global fallback, `script.test.ts` for `formatClubName`.

### Concerns & Comments

- Diagnostics gate green: `npx tsc --noEmit` clean, `npx @astrojs/check` 0 errors / 0 warnings (with a single hint about an unused `pageTitle` prop in an existing layout — pre-existing, untouched by this PR), `npm test` 129 passed across 18 files, `npm run build` succeeds.
- The original sandbox run logged a transient "Cannot connect to API … astro:assets" during `astro check`; re-verified here in a clean worktree the check passes with 0 errors — that was an outbound-network blip, not a code failure.
- Clarified `#60`'s "temporary simplification" comment in `loaders/events.ts` now that the per-chapter filter lands: online events stay global on the public site, but a chapter's own events can still be filtered online/in-person.