### PR TITLE
Wire Mailchimp segmentation to club membership

### DIFF
--- a/src/actions/clubMembers.test.ts
+++ b/src/actions/clubMembers.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Handler-level tests for updateClubMemberships. Astro actions don't expose
+// their `handler` in tests, so `defineAction` is mocked to return the
+// definition object as-is (giving us the raw handler to invoke) and
+// `ActionError` is stubbed with the same shape the real class throws
+// (`code` + `message`). The Supabase admin client is mocked table by table,
+// same chained shape as real supabase-js, with `state` letting each test
+// control exactly what comes back. Mailchimp is mocked wholesale so no test
+// can make a live API call (see #55) — state.tagError forces a tag call to
+// fail so the best-effort sync path can be exercised.
+const state = vi.hoisted(() => ({
+  payload: { memberId: "member-1", isAdmin: false } as { memberId: string; isAdmin: boolean } | null,
+  existingClubIds: [] as number[],
+  clubsQueryError: null as Error | null,
+  insertError: null as Error | null,
+  insertRows: [] as { member_id: string; club_id: number }[],
+  deleteError: null as Error | null,
+  deleteMemberId: null as string | null,
+  deleteNotOp: null as string | null,
+  // #55: data the Mailchimp tag sync reads back (member email + every
+  // club's id/slug), plus a way to make a tag call fail.
+  memberEmail: null as string | null,
+  memberEmailError: null as Error | null,
+  allClubs: [] as { id: number; slug: string }[],
+  allClubsError: null as Error | null,
+  tagError: null as Error | null,
+}));
+
+vi.mock("astro:actions", () => {
+  class MockActionError extends Error {
+    code: string;
+    constructor(params: { message?: string; code: string }) {
+      super(params.message);
+      this.name = "ActionError";
+      this.code = params.code;
+    }
+  }
+  return {
+    defineAction: (definition: { accept: string; handler: unknown }) => definition,
+    ActionError: MockActionError,
+  };
+});
+
+vi.mock("../lib/auth", () => ({
+  verifySessionToken: () => state.payload,
+}));
+
+// Mocking ../lib/supabase (below) also skips its `import "dotenv/config"`
+// side effect, so SUPABASE_* / JWT_SECRET never load from .env — none of
+// them are read here (verifySessionToken is mocked, supabaseAdmin is
+// replaced), so that's fine.
+vi.mock("../lib/supabase", () => ({
+  supabaseAdmin: {
+    from: (table: string) => {
+      if (table === "clubs") {
+        return {
+          select: (fields: string) => {
+            // #55: club validation is `select('id').in(...)`; the Mailchimp
+            // tag sync reads every club with `select('id, slug')` (awaited
+            // directly). Branch on the field list to serve each shape.
+            if (fields === "id, slug") {
+              return Promise.resolve({ data: state.allClubs, error: state.allClubsError });
+            }
+            return {
+              in: (_column: string, ids: number[]) =>
+                Promise.resolve({
+                  data: ids.filter((id) => state.existingClubIds.includes(id)).map((id) => ({ id })),
+                  error: state.clubsQueryError,
+                }),
+            };
+          },
+        };
+      }
+      if (table === "members") {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: state.memberEmail ? { email: state.memberEmail } : null,
+                  error: state.memberEmailError,
+                }),
+            }),
+          }),
+        };
+      }
+      if (table === "club_members") {
+        return {
+          upsert: (rows: { member_id: string; club_id: number }[]) => {
+            state.insertRows = rows;
+            return Promise.resolve({ error: state.insertError });
+          },
+          delete: () => ({
+            eq: (_column: string, memberId: string) => {
+              state.deleteMemberId = memberId;
+              const deleteChain = {
+                not: (_column2: string, _operation: string, opValue: string) => {
+                  state.deleteNotOp = opValue;
+                  return Promise.resolve({ error: state.deleteError });
+                },
+              };
+              // Awaitable (no .not when every club is being unselected) and
+              // chainable (.not returns the final error result).
+              return Object.assign(deleteChain, Promise.resolve({ error: state.deleteError }));
+            },
+          }),
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  },
+}));
+
+vi.mock("../lib/mailchimp", () => ({
+  addClubTag: vi.fn(async () => {
+    if (state.tagError) throw state.tagError;
+  }),
+  removeClubTag: vi.fn(async () => {
+    if (state.tagError) throw state.tagError;
+  }),
+}));
+
+import { updateClubMemberships } from "./clubMembers";
+import { addClubTag, removeClubTag } from "../lib/mailchimp";
+
+// The mocked defineAction above returns the definition object (not Astro's
+// real client wrapper), so the raw handler is what reaches `handler`.
+const action = updateClubMemberships as unknown as {
+  handler: (formData: FormData, context: { cookies: { get: (name: string) => { value: string } | null } }) => Promise<{ success: boolean; club_ids: number[] }>;
+};
+
+function makeContext(session?: string) {
+  return {
+    cookies: {
+      get: (name: string) => (name === "session" && session ? { value: session } : null),
+    },
+  };
+}
+
+function run(formData: FormData, session = "session-token") {
+  return action.handler(formData, makeContext(session));
+}
+
+describe("updateClubMemberships", () => {
+  beforeEach(() => {
+    state.payload = { memberId: "member-1", isAdmin: false };
+    state.existingClubIds = [];
+    state.clubsQueryError = null;
+    state.insertError = null;
+    state.insertRows = [];
+    state.deleteError = null;
+    state.deleteMemberId = null;
+    state.deleteNotOp = null;
+    state.memberEmail = null;
+    state.memberEmailError = null;
+    state.allClubs = [];
+    state.allClubsError = null;
+    state.tagError = null;
+    vi.mocked(addClubTag).mockClear();
+    vi.mocked(removeClubTag).mockClear();
+  });
+
+  it("rejects with UNAUTHORIZED when there is no session cookie", async () => {
+    await expect(run(new FormData(), "")).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    expect(addClubTag).not.toHaveBeenCalled();
+    expect(removeClubTag).not.toHaveBeenCalled();
+  });
+
+  it("rejects with UNAUTHORIZED when the session token does not verify", async () => {
+    state.payload = null;
+
+    await expect(run(new FormData(), "session-token")).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    expect(addClubTag).not.toHaveBeenCalled();
+    expect(removeClubTag).not.toHaveBeenCalled();
+  });
+
+  it("registers to each selected club and tags on in Mailchimp", async () => {
+    state.existingClubIds = [1, 2];
+    state.memberEmail = "member@example.com";
+    state.allClubs = [
+      { id: 1, slug: "trieste" },
+      { id: 2, slug: "rome" },
+      { id: 3, slug: "venice" },
+    ];
+    const formData = new FormData();
+    formData.append("club_id", "1");
+    formData.append("club_id", "2");
+    formData.append("club_id", "1"); // duplicate — one membership per (member, club)
+
+    await expect(run(formData)).resolves.toEqual({ success: true, club_ids: [1, 2] });
+
+    expect(state.insertRows).toEqual([
+      { member_id: "member-1", club_id: 1 },
+      { member_id: "member-1", club_id: 2 },
+    ]);
+    expect(state.deleteMemberId).toBe("member-1");
+    expect(state.deleteNotOp).toBe("(1,2)");
+
+    // #55: selected clubs tagged on; unselected club left behind tagged off.
+    expect(addClubTag).toHaveBeenCalledWith("member@example.com", "trieste");
+    expect(addClubTag).toHaveBeenCalledWith("member@example.com", "rome");
+    expect(removeClubTag).toHaveBeenCalledWith("member@example.com", "venice");
+    expect(addClubTag).toHaveBeenCalledTimes(2);
+    expect(removeClubTag).toHaveBeenCalledTimes(1);
+  });
+
+  it("unregisters from every club and tags every club off when nothing is checked", async () => {
+    state.memberEmail = "member@example.com";
+    state.allClubs = [
+      { id: 1, slug: "trieste" },
+      { id: 2, slug: "rome" },
+    ];
+
+    await expect(run(new FormData())).resolves.toEqual({ success: true, club_ids: [] });
+
+    expect(state.insertRows).toEqual([]);
+    expect(state.deleteMemberId).toBe("member-1");
+    expect(state.deleteNotOp).toBeNull();
+
+    expect(addClubTag).not.toHaveBeenCalled();
+    expect(removeClubTag).toHaveBeenCalledWith("member@example.com", "trieste");
+    expect(removeClubTag).toHaveBeenCalledWith("member@example.com", "rome");
+  });
+
+  it("ignores blank or malformed club_id values instead of treating them as club ids", async () => {
+    state.existingClubIds = [1];
+    state.memberEmail = "member@example.com";
+    state.allClubs = [{ id: 1, slug: "trieste" }];
+    const formData = new FormData();
+    formData.append("club_id", "1");
+    formData.append("club_id", "");
+
+    await expect(run(formData)).resolves.toEqual({ success: true, club_ids: [1] });
+
+    expect(state.insertRows).toEqual([{ member_id: "member-1", club_id: 1 }]);
+    expect(state.deleteNotOp).toBe("(1)");
+  });
+
+  it("skips the Mailchimp sync entirely when the member has no stored email", async () => {
+    state.existingClubIds = [1];
+    state.memberEmail = null;
+    state.allClubs = [{ id: 1, slug: "trieste" }];
+    const formData = new FormData();
+    formData.append("club_id", "1");
+
+    await expect(run(formData)).resolves.toEqual({ success: true, club_ids: [1] });
+
+    expect(addClubTag).not.toHaveBeenCalled();
+    expect(removeClubTag).not.toHaveBeenCalled();
+  });
+
+  it("keeps the membership update successful when a Mailchimp tag call fails", async () => {
+    state.existingClubIds = [1];
+    state.memberEmail = "member@example.com";
+    state.allClubs = [{ id: 1, slug: "trieste" }];
+    state.tagError = new Error("Mailchimp is down");
+    const formData = new FormData();
+    formData.append("club_id", "1");
+
+    await expect(run(formData)).resolves.toEqual({ success: true, club_ids: [1] });
+
+    expect(addClubTag).toHaveBeenCalledWith("member@example.com", "trieste");
+  });
+
+  it("rejects with BAD_REQUEST when a selected club does not exist", async () => {
+    state.existingClubIds = [1];
+    state.memberEmail = "member@example.com";
+    state.allClubs = [{ id: 1, slug: "trieste" }];
+    const formData = new FormData();
+    formData.append("club_id", "1");
+    formData.append("club_id", "99");
+
+    await expect(run(formData)).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(state.insertRows).toEqual([]);
+    expect(addClubTag).not.toHaveBeenCalled();
+    expect(removeClubTag).not.toHaveBeenCalled();
+  });
+
+  it("rejects with INTERNAL_SERVER_ERROR when the clubs lookup fails", async () => {
+    state.existingClubIds = [1];
+    state.clubsQueryError = new Error("boom");
+    const formData = new FormData();
+    formData.append("club_id", "1");
+
+    await expect(run(formData)).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
+    expect(addClubTag).not.toHaveBeenCalled();
+    expect(removeClubTag).not.toHaveBeenCalled();
+  });
+
+  it("rejects with INTERNAL_SERVER_ERROR when the membership insert fails", async () => {
+    state.existingClubIds = [1];
+    state.insertError = new Error("boom");
+    const formData = new FormData();
+    formData.append("club_id", "1");
+
+    await expect(run(formData)).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
+    expect(addClubTag).not.toHaveBeenCalled();
+    expect(removeClubTag).not.toHaveBeenCalled();
+  });
+
+  it("rejects with INTERNAL_SERVER_ERROR when the membership delete fails", async () => {
+    state.existingClubIds = [1];
+    state.deleteError = new Error("boom");
+    const formData = new FormData();
+    formData.append("club_id", "1");
+
+    await expect(run(formData)).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
+    expect(addClubTag).not.toHaveBeenCalled();
+    expect(removeClubTag).not.toHaveBeenCalled();
+  });
+});

--- a/src/actions/clubMembers.ts
+++ b/src/actions/clubMembers.ts
@@ -1,6 +1,40 @@
 import { defineAction, ActionError } from 'astro:actions';
 import { verifySessionToken } from '../lib/auth';
 import { supabaseAdmin } from '../lib/supabase';
+import { addClubTag, removeClubTag } from '../lib/mailchimp';
+
+// #55: mirror the member's club subscriptions onto Mailchimp member tags
+// (club:<slug>) so event emails can target one club's audience. Everything
+// checked stays tagged on, everything not checked (against the full club
+// list) is tagged off — an idempotent upsert, so saving the same choice
+// again is a no-op, and a member with no stored email just skips out.
+async function syncMailchimpClubTags(memberId: string, selectedClubIds: number[]): Promise<void> {
+  if (!supabaseAdmin) return;
+
+  const { data: member, error: memberError } = await supabaseAdmin
+    .from('members')
+    .select('email')
+    .eq('id', memberId)
+    .single();
+  if (memberError || !member?.email) return;
+
+  const { data: clubs, error: clubsError } = await supabaseAdmin
+    .from('clubs')
+    .select('id, slug');
+  if (clubsError) return;
+
+  const slugById = new Map((clubs ?? []).map((club) => [club.id, club.slug]));
+  const leavingClubIds = (clubs ?? []).map((club) => club.id).filter((id) => !selectedClubIds.includes(id));
+
+  for (const id of selectedClubIds) {
+    const slug = slugById.get(id);
+    if (slug) await addClubTag(member.email, slug);
+  }
+  for (const id of leavingClubIds) {
+    const slug = slugById.get(id);
+    if (slug) await removeClubTag(member.email, slug);
+  }
+}
 
 // #38: any logged-in member can register to any club — this is purely an
 // opt-in to that club's news/updates, not a gate on browsing/RSVP (which
@@ -70,6 +104,16 @@ export const updateClubMemberships = defineAction({
 
     if (deleteError) {
       throw new ActionError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to update club subscriptions' });
+    }
+
+    // #55: keep the Mailchimp tags in line with the new membership set.
+    // Best effort never fails the request — same posture as the event email
+    // in createEvent — so a transient Mailchimp outage can't strand the
+    // member with a half-applied club change.
+    try {
+      await syncMailchimpClubTags(payload.memberId, selectedClubIds);
+    } catch (err) {
+      console.error('Mailchimp club tag sync failed:', err);
     }
 
     return { success: true, club_ids: selectedClubIds };

--- a/src/actions/events.test.ts
+++ b/src/actions/events.test.ts
@@ -357,7 +357,14 @@ describe('createEvent', () => {
     expect(state.rsvpInsertPayload).toMatchObject({ member_id: 'admin-1', event_id: 42, status: 'going' });
     expect(state.rsvpInsertPayload?.updated_at).toEqual(expect.any(String));
     expect(state.netlifyBuildCalled).toBe(true);
-    expect(state.mailchimpCall).toMatchObject({ slug: 'philosophy-night', club_slug: DEFAULT_CLUB_SLUG });
+    // Cross-chapter (club_id null): club_slug still falls back to
+    // DEFAULT_CLUB_SLUG for the CTA link, but is_cross_chapter must be true
+    // so mailchimp.ts doesn't narrow the audience to that one club.
+    expect(state.mailchimpCall).toMatchObject({
+      slug: 'philosophy-night',
+      club_slug: DEFAULT_CLUB_SLUG,
+      is_cross_chapter: true,
+    });
   });
 
   it("creates an in-person event via an existing venue, using the venue's club", async () => {
@@ -380,7 +387,11 @@ describe('createEvent', () => {
     expect(result).toEqual({ success: true });
     expect(state.insertedEvent).toMatchObject({ venue_id: 5, club_id: 3, created_by: 'admin-2' });
     expect(state.rsvpInsertPayload).toMatchObject({ member_id: 'admin-2', event_id: 43, status: 'going' });
-    expect(state.mailchimpCall).toMatchObject({ club_slug: 'galway', venue_name: 'The Reading Room' });
+    expect(state.mailchimpCall).toMatchObject({
+      club_slug: 'galway',
+      is_cross_chapter: false,
+      venue_name: 'The Reading Room',
+    });
   });
 
   it('still creates the event when seeding the host RSVP fails', async () => {

--- a/src/actions/events.ts
+++ b/src/actions/events.ts
@@ -159,10 +159,14 @@ export const createEvent = defineAction({
 
     // #39: events are routed under /[clubSlug]/events — a cross-chapter
     // event (event_club_id null) has no club of its own to link into, so
-    // the draft email falls back to the one club that exists today. A
-    // single-row lookup, not getAllClubs() — no need to fetch every club
-    // just to read one slug (and event_club_id null can never match a row
-    // anyway, so that path would always fetch and discard the whole table).
+    // the draft email's CTA link falls back to the one club that exists
+    // today. A single-row lookup, not getAllClubs() — no need to fetch
+    // every club just to read one slug (and event_club_id null can never
+    // match a row anyway, so that path would always fetch and discard the
+    // whole table). This fallback is link-only: it must not also decide
+    // who receives the email (see is_cross_chapter below) — #64's
+    // segment-per-club targeting would otherwise silently narrow a
+    // cross-chapter event's audience down to just that one club.
     let club_slug: string = DEFAULT_CLUB_SLUG;
     if (event_club_id !== null) {
       const { data: club, error: clubError } = await supabaseAdmin
@@ -179,6 +183,7 @@ export const createEvent = defineAction({
       date,
       slug,
       club_slug,
+      is_cross_chapter: event_club_id === null,
       meeting_url,
       venue_name: venue?.name ?? null,
       venue_url: venue?.url ?? null,

--- a/src/lib/mailchimp.test.ts
+++ b/src/lib/mailchimp.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import { createHash } from 'crypto';
+
+// The module captures MAILCHIMP_API_KEY/DC at import time, so the env must be
+// set before the import below evaluates (vi.hoisted runs before imports).
+vi.hoisted(() => {
+  process.env.MAILCHIMP_API_KEY = 'testkey-us1';
+  process.env.MAILCHIMP_AUDIENCE_ID = 'audience-123';
+});
+
+import {
+  addClubTag,
+  removeClubTag,
+  sendMailchimpEmail,
+  clubTagFor,
+  mailchimpRuntime,
+} from './mailchimp';
+
+const US1 = 'https://us1.api.mailchimp.com/3.0';
+const HASH = createHash('md5').update('member@example.com').digest('hex');
+
+// Stub the network: every Mailchimp call goes through global fetch, so
+// replacing it means no test can reach the live API (see #55 acceptance).
+function fetchMock() {
+  return vi.mocked(globalThis.fetch);
+}
+
+function fakeResponse(body: unknown, status = 200) {
+  const ok = status >= 200 && status < 300;
+  return {
+    ok,
+    status,
+    statusText: `status ${status}`,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function memberUpsertResponse() {
+  return fakeResponse({ id: 'member-id', email_address: 'member@example.com', status: 'subscribed' });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+afterAll(() => {
+  delete process.env.MAILCHIMP_API_KEY;
+  delete process.env.MAILCHIMP_AUDIENCE_ID;
+});
+
+describe('clubTagFor', () => {
+  it('namespaces a club slug under club:', () => {
+    expect(clubTagFor('trieste')).toBe('club:trieste');
+  });
+});
+
+describe('addClubTag', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  it('upserts the member into the audience then activates the club tag', async () => {
+    fetchMock()
+      .mockResolvedValueOnce(memberUpsertResponse())
+      .mockResolvedValueOnce(fakeResponse({}, 200));
+
+    // Member email in the URL hash is lowercased/trimmed; the body keeps the
+    // stored casing.
+    await addClubTag('Member@Example.COM ', 'trieste');
+
+    expect(fetchMock()).toHaveBeenCalledTimes(2);
+
+    const [upsertUrl, upsertInit] = fetchMock().mock.calls[0] as [string, RequestInit];
+    expect(upsertUrl).toBe(`${US1}/lists/audience-123/members/${HASH}`);
+    expect(upsertInit.method).toBe('PUT');
+    expect(JSON.parse(String(upsertInit.body))).toEqual({
+      email_address: 'Member@Example.COM ',
+      status_if_new: 'subscribed',
+    });
+    expect(String(new Headers(upsertInit.headers).get('Authorization'))).toMatch(/^Basic /);
+
+    const [tagUrl, tagInit] = fetchMock().mock.calls[1] as [string, RequestInit];
+    expect(tagUrl).toBe(`${US1}/lists/audience-123/members/${HASH}/tags`);
+    expect(tagInit.method).toBe('POST');
+    expect(JSON.parse(String(tagInit.body))).toEqual({
+      tags: [{ name: 'club:trieste', status: 'active' }],
+    });
+  });
+
+  it('throws when the member upsert is rejected by the API', async () => {
+    fetchMock().mockResolvedValueOnce(
+      fakeResponse({ title: 'Invalid Resource', detail: 'The resource submitted could not be validated.' }, 400)
+    );
+
+    await expect(addClubTag('member@example.com', 'trieste')).rejects.toThrow(
+      /Mailchimp member upsert failed: The resource submitted could not be validated\./
+    );
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('removeClubTag', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  it('drops the club tag but leaves the contact on the audience', async () => {
+    fetchMock().mockResolvedValueOnce(fakeResponse({}, 200));
+
+    await removeClubTag('member@example.com', 'trieste');
+
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock().mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${US1}/lists/audience-123/members/${HASH}/tags`);
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(String(init.body))).toEqual({
+      tags: [{ name: 'club:trieste', status: 'inactive' }],
+    });
+  });
+
+  it('treats a missing contact (404) as already untagged', async () => {
+    fetchMock().mockResolvedValueOnce(fakeResponse({ title: 'Resource Not Found' }, 404));
+
+    await expect(removeClubTag('member@example.com', 'trieste')).resolves.toBeUndefined();
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('sendMailchimpEmail', () => {
+  // The campaign path is dev-gated, but vitest runs with import.meta.env.DEV
+  // === true — flip the seam so these tests exercise the real call sequence
+  // against the stubbed fetch. One test below keeps the guard on to prove
+  // the dev skip.
+  beforeEach(() => {
+    vi.spyOn(mailchimpRuntime, 'isLocalDev').mockReturnValue(false);
+    globalThis.fetch = vi.fn();
+  });
+
+  it('routes the event draft to the event club segment', async () => {
+    fetchMock()
+      .mockResolvedValueOnce(fakeResponse({
+        segments: [
+          { id: 7, name: 'club:trieste' },
+          { id: 8, name: 'club:rome' },
+        ],
+      }))
+      .mockResolvedValueOnce(fakeResponse({ id: 'campaign-1' }))
+      .mockResolvedValueOnce(fakeResponse({}, 200))
+      .mockResolvedValueOnce(fakeResponse({}, 200));
+
+    await sendMailchimpEmail({
+      name: 'Coffee Morning',
+      date: '2026-09-01T10:00:00Z',
+      slug: 'coffee-morning',
+      club_slug: 'trieste',
+      is_cross_chapter: false,
+      meeting_url: null,
+      venue_name: null,
+      venue_url: null,
+    });
+
+    expect(fetchMock()).toHaveBeenCalledTimes(4);
+
+    const [segmentsUrl] = fetchMock().mock.calls[0] as [string, RequestInit];
+    expect(segmentsUrl).toBe(`${US1}/lists/audience-123/segments?count=1000&offset=0`);
+
+    const [, campaignInit] = fetchMock().mock.calls[1] as [string, RequestInit];
+    expect(campaignInit.method).toBe('POST');
+    const campaignBody = JSON.parse(String(campaignInit.body));
+    expect(campaignBody.recipients).toEqual({
+      list_id: 'audience-123',
+      segment_opts: { saved_segment_id: 7 },
+    });
+    expect(campaignBody.settings).toMatchObject({
+      subject_line: 'Upcoming event - Coffee Morning',
+      from_name: 'Club na Féalscúnachta',
+    });
+
+    const [contentUrl, contentInit] = fetchMock().mock.calls[2] as [string, RequestInit];
+    expect(contentUrl).toBe(`${US1}/campaigns/campaign-1/content`);
+    expect(contentInit.method).toBe('PUT');
+    expect(String(contentInit.body)).toContain('Coffee Morning');
+
+    const [sendUrl, sendInit] = fetchMock().mock.calls[3] as [string, RequestInit];
+    expect(sendUrl).toBe(`${US1}/campaigns/campaign-1/actions/send`);
+    expect(sendInit.method).toBe('POST');
+  });
+
+  it('skips the send when the event club has no segment yet', async () => {
+    fetchMock().mockResolvedValueOnce(fakeResponse({ segments: [{ id: 7, name: 'club:trieste' }] }));
+
+    await expect(
+      sendMailchimpEmail({
+        name: 'Venice Meetup',
+        date: '2026-10-01T10:00:00Z',
+        slug: 'venice-meetup',
+        club_slug: 'venice',
+        is_cross_chapter: false,
+        meeting_url: null,
+        venue_name: null,
+        venue_url: null,
+      })
+    ).resolves.toBeUndefined();
+
+    // Only the segments lookup happened — no campaign was created.
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it('pages through the segments list when the club segment is past the first page', async () => {
+    // A full first page (no match) forces a second request at the next offset.
+    const firstPage = Array.from({ length: 1000 }, (_, i) => ({ id: i, name: `club:filler-${i}` }));
+
+    fetchMock()
+      .mockResolvedValueOnce(fakeResponse({ segments: firstPage }))
+      .mockResolvedValueOnce(fakeResponse({ segments: [{ id: 42, name: 'club:trieste' }] }))
+      .mockResolvedValueOnce(fakeResponse({ id: 'campaign-1' }))
+      .mockResolvedValueOnce(fakeResponse({}, 200))
+      .mockResolvedValueOnce(fakeResponse({}, 200));
+
+    await sendMailchimpEmail({
+      name: 'Coffee Morning',
+      date: '2026-09-01T10:00:00Z',
+      slug: 'coffee-morning',
+      club_slug: 'trieste',
+      is_cross_chapter: false,
+      meeting_url: null,
+      venue_name: null,
+      venue_url: null,
+    });
+
+    expect(fetchMock()).toHaveBeenCalledTimes(5);
+    const [firstUrl] = fetchMock().mock.calls[0] as [string, RequestInit];
+    const [secondUrl] = fetchMock().mock.calls[1] as [string, RequestInit];
+    expect(firstUrl).toBe(`${US1}/lists/audience-123/segments?count=1000&offset=0`);
+    expect(secondUrl).toBe(`${US1}/lists/audience-123/segments?count=1000&offset=1000`);
+
+    const [, campaignInit] = fetchMock().mock.calls[2] as [string, RequestInit];
+    expect(JSON.parse(String(campaignInit.body)).recipients).toEqual({
+      list_id: 'audience-123',
+      segment_opts: { saved_segment_id: 42 },
+    });
+  });
+
+  it('does not hit the network from a local dev runtime', async () => {
+    vi.spyOn(mailchimpRuntime, 'isLocalDev').mockReturnValue(true);
+
+    await sendMailchimpEmail({
+      name: 'Coffee Morning',
+      date: '2026-09-01T10:00:00Z',
+      slug: 'coffee-morning',
+      club_slug: 'trieste',
+      is_cross_chapter: false,
+      meeting_url: null,
+      venue_name: null,
+      venue_url: null,
+    });
+
+    expect(fetchMock()).not.toHaveBeenCalled();
+  });
+
+  it('skips a cross-chapter event entirely rather than notifying one club or everyone', async () => {
+    await sendMailchimpEmail({
+      name: 'Annual Gathering',
+      date: '2026-11-01T10:00:00Z',
+      slug: 'annual-gathering',
+      // club_slug still carries the CTA-link fallback (see #39), but
+      // is_cross_chapter must be what decides whether the email goes out
+      // at all — no segment exists for "every club at once".
+      club_slug: 'trieste',
+      is_cross_chapter: true,
+      meeting_url: null,
+      venue_name: null,
+      venue_url: null,
+    });
+
+    expect(fetchMock()).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/mailchimp.ts
+++ b/src/lib/mailchimp.ts
@@ -1,8 +1,57 @@
 import { DEFAULT_CLUB_TIMEZONE } from './clubDefaults';
+import { createHash } from 'crypto';
 
 const MAILCHIMP_API_KEY = process.env.MAILCHIMP_API_KEY;
 const MAILCHIMP_AUDIENCE_ID = process.env.MAILCHIMP_AUDIENCE_ID;
 const DC = MAILCHIMP_API_KEY?.split('-')[1];
+
+// #55: club subscriptions are mirrored onto Mailchimp member tags named
+// club:<slug> (e.g. club:trieste). The anonymous newsletter form
+// (subscribe.ts) creates untagged contacts; this is the tagged lane.
+export const CLUB_TAG_PREFIX = 'club:';
+
+export function clubTagFor(clubSlug: string): string {
+  return `${CLUB_TAG_PREFIX}${clubSlug}`;
+}
+
+// Test seam: vitest runs with import.meta.env.DEV === true, which would
+// otherwise silently no-op every campaign send. Spying this flag in unit
+// tests lets them exercise the real Mailchimp call paths against a stubbed
+// fetch, while the guard itself still applies whenever the app actually
+// runs in dev.
+export const mailchimpRuntime = {
+  isLocalDev: (): boolean => import.meta.env.DEV,
+};
+
+function isConfigured(): boolean {
+  return Boolean(MAILCHIMP_API_KEY && MAILCHIMP_AUDIENCE_ID && DC);
+}
+
+function subscriberHash(email: string): string {
+  return createHash('md5').update(email.trim().toLowerCase()).digest('hex');
+}
+
+async function mailchimpError(res: Response): Promise<Error> {
+  let detail: string | undefined;
+  try {
+    const body = (await res.json()) as { detail?: string; title?: string };
+    detail = body.detail ?? body.title;
+  } catch {
+    // Some proxies return non-JSON error bodies — fall through to the status.
+  }
+  return new Error(detail ?? `${res.status} ${res.statusText}`);
+}
+
+async function mailchimp(requestPath: string, init?: { method?: string; body?: unknown }): Promise<Response> {
+  return fetch(`https://${DC}.api.mailchimp.com/3.0${requestPath}`, {
+    method: init?.method ?? 'GET',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`any:${MAILCHIMP_API_KEY}`).toString('base64')}`,
+      ...(init?.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+}
 
 const SITE_URL = 'https://clubnafealsunachta.com';
 const GREEN = '#314837';
@@ -17,7 +66,15 @@ export interface EventDraft {
   name: string;
   date: string;
   slug: string;
+  // Link-only: which club's page the CTA points to (falls back to
+  // DEFAULT_CLUB_SLUG for a cross-chapter event, which has no page of its
+  // own — see #39). Not the audience — see is_cross_chapter.
   club_slug: string;
+  // True for an event with no single owning club (event_club_id null).
+  // No segment exists for "every club at once", so a cross-chapter event
+  // has no one subscribed to notify — sendMailchimpEmail skips it rather
+  // than guessing at a club or blasting the whole audience.
+  is_cross_chapter: boolean;
   meeting_url?: string | null;
   venue_name?: string | null;
   venue_url?: string | null;
@@ -232,84 +289,171 @@ function buildPostEmailHtml(post: PostDraft): string {
   });
 }
 
-async function sendCampaign({ subjectLine, previewText, html }: {
+// The tags endpoint only updates the tags explicitly named in the request —
+// setting one "inactive" is how a tag is removed (the contact stays on the
+// audience). A 404 means the contact has never been on the audience at all
+// (e.g. a member who is only ever unsubscribing), so there is nothing to
+// untag: treat it as done.
+async function setMemberTags(email: string, tags: { name: string; status: 'active' | 'inactive' }[]): Promise<void> {
+  const res = await mailchimp(`/lists/${MAILCHIMP_AUDIENCE_ID}/members/${subscriberHash(email)}/tags`, {
+    method: 'POST',
+    body: { tags },
+  });
+  if (res.ok || res.status === 404) return;
+  throw new Error(`Mailchimp tag update failed: ${(await mailchimpError(res)).message}`);
+}
+
+// Join a club: make sure the member's email is on the audience (creating the
+// contact as subscribed if new, leaving an existing contact's status
+// untouched) and carry the club:<slug> tag. Not dev-gated like the campaign
+// send — same posture as subscribe.ts, a real user gesture.
+export async function addClubTag(email: string, clubSlug: string): Promise<void> {
+  if (!isConfigured()) {
+    console.warn('Mailchimp not configured — skipping tag update');
+    return;
+  }
+  const res = await mailchimp(`/lists/${MAILCHIMP_AUDIENCE_ID}/members/${subscriberHash(email)}`, {
+    method: 'PUT',
+    body: { email_address: email, status_if_new: 'subscribed' },
+  });
+  if (!res.ok) {
+    throw new Error(`Mailchimp member upsert failed: ${(await mailchimpError(res)).message}`);
+  }
+  await setMemberTags(email, [{ name: clubTagFor(clubSlug), status: 'active' }]);
+}
+
+// Leave a club: keep the contact, drop the club:<slug> tag.
+export async function removeClubTag(email: string, clubSlug: string): Promise<void> {
+  if (!isConfigured()) {
+    console.warn('Mailchimp not configured — skipping tag update');
+    return;
+  }
+  await setMemberTags(email, [{ name: clubTagFor(clubSlug), status: 'inactive' }]);
+}
+
+// Mailchimp's segments list endpoint pages by default; 1000 is the API's own
+// max count per page. Without paging through, a club whose segment falls
+// past the first page would be indistinguishable from "no segment yet".
+const SEGMENTS_PAGE_SIZE = 1000;
+
+// Resolve the audience segment id whose name is the club's tag. Tags are
+// static segments on the audience (same name), so targeting one club's
+// subscribers is a saved_segment_id in the campaign recipients (see #55).
+async function clubSegmentId(clubSlug: string): Promise<number | null> {
+  const targetName = clubTagFor(clubSlug);
+  let offset = 0;
+  while (true) {
+    const res = await mailchimp(`/lists/${MAILCHIMP_AUDIENCE_ID}/segments?count=${SEGMENTS_PAGE_SIZE}&offset=${offset}`);
+    if (!res.ok) {
+      throw new Error(`Mailchimp segment lookup failed: ${(await mailchimpError(res)).message}`);
+    }
+    const body = (await res.json()) as { segments?: { id: number; name: string }[] };
+    const match = body.segments?.find((segment) => segment.name === targetName);
+    if (match) return match.id;
+    if (!body.segments || body.segments.length < SEGMENTS_PAGE_SIZE) return null;
+    offset += SEGMENTS_PAGE_SIZE;
+  }
+}
+
+async function sendCampaign({ subjectLine, previewText, html, recipients }: {
   subjectLine: string;
   previewText: string;
   html: string;
+  recipients: Record<string, unknown>;
 }): Promise<void> {
   // Never hit the real Mailchimp account from a local dev server, even if
   // a real API key is present in .env (e.g. pulled down via sync-env) —
   // creating draft campaigns while testing locally would clutter the live
   // account. Astro sets DEV based on how the app is actually running, not
-  // on env-var presence, so there's nothing to remember to unset.
-  if (import.meta.env.DEV) {
+  // on env-var presence, so there's nothing to remember to unset. See
+  // mailchimpRuntime above for why the check goes through an indirection.
+  if (mailchimpRuntime.isLocalDev()) {
     console.warn(`Mailchimp campaign skipped in local dev: "${subjectLine}"`);
     return;
   }
 
-  const authHeader = `Basic ${Buffer.from(`any:${MAILCHIMP_API_KEY}`).toString('base64')}`;
-  const baseUrl = `https://${DC}.api.mailchimp.com/3.0`;
-
-  const campaignRes = await fetch(`${baseUrl}/campaigns`, {
+  const campaignRes = await mailchimp('/campaigns', {
     method: 'POST',
-    headers: { Authorization: authHeader, 'Content-Type': 'application/json' },
-    body: JSON.stringify({
+    body: {
       type: 'regular',
-      recipients: { list_id: MAILCHIMP_AUDIENCE_ID },
+      recipients,
       settings: {
         subject_line: subjectLine,
         preview_text: previewText,
         from_name: 'Club na Féalscúnachta',
         reply_to: process.env.EMAIL_INFO,
       },
-    }),
+    },
   });
 
   if (!campaignRes.ok) {
-    const err = await campaignRes.json();
-    throw new Error(`Mailchimp campaign creation failed: ${err.detail ?? campaignRes.statusText}`);
+    throw new Error(`Mailchimp campaign creation failed: ${(await mailchimpError(campaignRes)).message}`);
   }
 
   const { id: campaignId } = await campaignRes.json();
 
-  const contentRes = await fetch(`${baseUrl}/campaigns/${campaignId}/content`, {
+  const contentRes = await mailchimp(`/campaigns/${campaignId}/content`, {
     method: 'PUT',
-    headers: { Authorization: authHeader, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ html }),
+    body: { html },
   });
 
   if (!contentRes.ok) {
-    const err = await contentRes.json();
-    throw new Error(`Mailchimp content update failed: ${err.detail ?? contentRes.statusText}`);
+    throw new Error(`Mailchimp content update failed: ${(await mailchimpError(contentRes)).message}`);
   }
 
-  const sendRes = await fetch(`${baseUrl}/campaigns/${campaignId}/actions/send`, {
+  const sendRes = await mailchimp(`/campaigns/${campaignId}/actions/send`, {
     method: 'POST',
-    headers: { Authorization: authHeader },
   });
 
   if (!sendRes.ok) {
-    const err = await sendRes.json();
-    throw new Error(`Mailchimp send failed: ${err.detail ?? sendRes.statusText}`);
+    throw new Error(`Mailchimp send failed: ${(await mailchimpError(sendRes)).message}`);
   }
 }
 
 export async function sendMailchimpEmail(event: EventDraft): Promise<void> {
-  if (!MAILCHIMP_API_KEY || !MAILCHIMP_AUDIENCE_ID || !DC) {
+  if (!isConfigured()) {
     console.warn('Mailchimp not configured — skipping email send');
     return;
   }
+  if (mailchimpRuntime.isLocalDev()) {
+    console.warn(`Mailchimp campaign skipped in local dev: "Upcoming event - ${event.name}"`);
+    return;
+  }
+
+  // #55: route the event draft to the event's club segment — never the
+  // whole audience. A club nobody has subscribed to yet has no segment at
+  // all, and a cross-chapter event has no single club to narrow to either;
+  // both mean no one has actually opted in to that email, so both are
+  // skipped rather than falling back to club_slug's link-only default or
+  // blasting everyone (that "whole audience" fallback silently included
+  // newsletter-only subscribers, contradicting the segment-only direction
+  // above — dropped once this was noticed).
+  if (event.is_cross_chapter) {
+    console.warn(`Cross-chapter event "${event.name}" has no club segment to notify — skipping event email`);
+    return;
+  }
+  const segmentId = await clubSegmentId(event.club_slug);
+  if (segmentId == null) {
+    console.warn(`No Mailchimp segment for "${clubTagFor(event.club_slug)}" — skipping event email`);
+    return;
+  }
+  const recipients = { list_id: MAILCHIMP_AUDIENCE_ID, segment_opts: { saved_segment_id: segmentId } };
 
   await sendCampaign({
     subjectLine: `Upcoming event - ${event.name}`,
     previewText: `Join us for ${event.name} — ${formatEventDate(event.date)}`,
     html: buildEventEmailHtml(event),
+    recipients,
   });
 }
 
 export async function sendMailchimpPostEmail(post: PostDraft): Promise<void> {
-  if (!MAILCHIMP_API_KEY || !MAILCHIMP_AUDIENCE_ID || !DC) {
+  if (!isConfigured()) {
     console.warn('Mailchimp not configured — skipping email send');
+    return;
+  }
+  if (mailchimpRuntime.isLocalDev()) {
+    console.warn(`Mailchimp campaign skipped in local dev: "New blog post - ${post.title}"`);
     return;
   }
 
@@ -317,5 +461,6 @@ export async function sendMailchimpPostEmail(post: PostDraft): Promise<void> {
     subjectLine: `New blog post - ${post.title}`,
     previewText: extractFirstParagraph(post.body).slice(0, 150),
     html: buildPostEmailHtml(post),
+    recipients: { list_id: MAILCHIMP_AUDIENCE_ID },
   });
 }


### PR DESCRIPTION
Closes #55.

### Why

Today the site's Mailchimp integration and its `members` table are entirely separate: `sendMailchimpEmail`/`sendMailchimpPostEmail` send one campaign to the whole audience (`recipients.list_id`), and the only thing that adds a contact is the anonymous newsletter form, with no link back to a member — so club membership has no route into Mailchimp, and event emails can't be aimed at the club that owns the event. This wires the two together: club membership drives per-club Mailchimp tags, and event emails go to the segment for the event's club.

### How it was achieved

- **Tag mirroring on membership change** (`src/actions/clubMembers.ts`) — after a member saves their club subscriptions, `syncMailchimpClubTags` diffs the new selection against the full club list and applies `club:<slug>` tags accordingly: upserting the member's email onto the audience (tag `active`) for clubs checked, tag `inactive` for clubs unchecked against the full list. Idempotent — saving the same choice again is a no-op; a member with no stored email is skipped. It runs best-effort inside a `try/catch` so a transient Mailchimp outage never fails the member's club update (same posture as the `createEvent` email).
- **Tag primitives** (`src/lib/mailchimp.ts`) — new `addClubTag` (PUT member: upsert contact as `subscribed` if new, leaving existing status untouched, then activate the tag) and `removeClubTag` (set the tag `inactive`; a 404 is treated as done since the contact was never on the audience). Contacts flow through the standard MD5 subscriber-hash endpoint.
- **Segment-targeted event emails** — `sendCampaign` now accepts `recipients`; `sendMailchimpEmail` looks up the event's club tag as a static segment (`clubSegmentId`) and sends **to that saved segment only**, skipping (with a warning) if the segment doesn't exist yet. Post emails still go to the whole audience (`sendMailchimpPostEmail` unchanged in behavior).
- **Local-dev safety seam** — the "never hit the real account in dev" check moved behind `mailchimpRuntime.isLocalDev()` (a test seam), since vitest runs with `import.meta.env.DEV` true and would otherwise silently no-op every send. Real Mailchimp calls are still dev-gated for campaign sends; tag calls are deliberately not (same posture as `subscribe.ts` — a real user gesture).
- **Mocks in CI** — `src/lib/mailchimp.test.ts` (+223) and `src/actions/clubMembers.test.ts` (+312) stub `fetch`; no live Mailchimp API calls in tests.

### Concerns & Comments

- Diagnostics gate green: `npx tsc --noEmit` clean, `npx @astrojs/check` 0 errors / 0 warnings (1 pre-existing hint), `npm test` 136 passed across 19 files, `npm run build` succeeds.
- **Operational prerequisite for the human:** this only takes effect once a second club exists, and each club needs a matching **static segment named `club:<slug>`** created in the Mailchimp audience admin — until then, event emails for that club are skipped (with a server-side warning), never crash. No segment exists for `trieste` yet.
- `addClubTag`/`removeClubTag` are *not* local-dev-gated (a deliberate, annotated choice, same as the newsletter form), so a dev server with a real `MAILCHIMP_API_KEY` will make live calls on club membership changes.
- Behavior change: event emails now reach only the event's club segment rather than the whole audience — expected, and the point of #55, but worth calling out.