### PR TITLE
Add "Join" button for online events

### DIFF
--- a/src/components/EventRsvp/EventRsvp.test.tsx
+++ b/src/components/EventRsvp/EventRsvp.test.tsx
@@ -238,14 +238,16 @@ describe("EventRsvp", () => {
     });
   });
 
-  it("keeps the RSVP controls off once the event has passed", async () => {
+  it("keeps the RSVP controls off and switches to past-tense wording once the event has passed", async () => {
     mockGetEventRsvps.mockResolvedValue({ data: memberState });
 
     render(<EventRsvp slug="philosophy-101" initialCounts={baseCounts} date="2000-01-01T18:00:00.000Z" />);
 
     await waitFor(() => {
-      expect(screen.getByText("Going")).toBeInTheDocument();
+      expect(screen.getByText("2 went · 1 maybe")).toBeInTheDocument();
     });
+    expect(screen.getByText("Went")).toBeInTheDocument();
+    expect(screen.queryByText("Going")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Going" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /log in/i })).not.toBeInTheDocument();
   });

--- a/src/components/EventRsvp/EventRsvp.tsx
+++ b/src/components/EventRsvp/EventRsvp.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import { actions } from "astro:actions";
 import { getDisplayName } from "../../lib/memberDisplay";
+import { isPastDate } from "../../utils/script";
 import Modal from "../Modal/Modal";
 import {
+  PAST_RSVP_LABELS,
   RSVP_LABELS,
   RSVP_STATUSES,
   type RsvpCounts,
@@ -31,7 +33,7 @@ export default function EventRsvp({ slug, initialCounts, date }: EventRsvpProps)
   const [showAttendees, setShowAttendees] = useState(false);
   const [loaded, setLoaded] = useState(false);
 
-  const eventHasPassed = new Date(date).getTime() < Date.now();
+  const eventHasPassed = isPastDate(date);
 
   useEffect(() => {
     let cancelled = false;
@@ -87,7 +89,12 @@ export default function EventRsvp({ slug, initialCounts, date }: EventRsvpProps)
   }
 
   const total = counts.going + counts.maybe + counts.not_going;
-  const summary = [counts.going > 0 && `${counts.going} going`, counts.maybe > 0 && `${counts.maybe} maybe`, counts.not_going > 0 && `${counts.not_going} not going`]
+  const labels = eventHasPassed ? PAST_RSVP_LABELS : RSVP_LABELS;
+  const summary = [
+    counts.going > 0 && `${counts.going} ${eventHasPassed ? "went" : "going"}`,
+    counts.maybe > 0 && `${counts.maybe} maybe`,
+    counts.not_going > 0 && `${counts.not_going} ${eventHasPassed ? "didn't go" : "not going"}`,
+  ]
     .filter(Boolean)
     .join(" · ");
 
@@ -153,7 +160,7 @@ export default function EventRsvp({ slug, initialCounts, date }: EventRsvpProps)
               lists[status].length > 0 ? (
                 <div key={status} className="cnf-rsvp__list">
                   <div className="cnf-rsvp__list-header">
-                    <h3 className="cnf-rsvp__list-title">{RSVP_LABELS[status]}</h3>
+                    <h3 className="cnf-rsvp__list-title">{labels[status]}</h3>
                     <span className="cnf-count" aria-hidden="true">{lists[status].length}</span>
                   </div>
                   <ul className="cnf-rsvp__list-members">

--- a/src/components/JoinEventButton/JoinEventButton.test.tsx
+++ b/src/components/JoinEventButton/JoinEventButton.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import JoinEventButton from "./JoinEventButton";
+import type { Event } from "../../types/types";
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    name: "Test Event",
+    date: new Date("2099-01-01"),
+    location: null,
+    isOnline: true,
+    venue: null,
+    slug: "test-event",
+    social: {},
+    meetingUrl: "https://meet.jit.si/test",
+    rsvpCounts: { going: 0, maybe: 0, not_going: 0 },
+    ...overrides,
+  };
+}
+
+describe("JoinEventButton", () => {
+  it("renders a Join online button linking to the meeting url for an upcoming online event", () => {
+    render(<JoinEventButton event={makeEvent()} />);
+    const link = screen.getByRole("link", { name: /join online/i });
+    expect(link).toHaveAttribute("href", "https://meet.jit.si/test");
+  });
+
+  it("does not render for in-person events", () => {
+    render(<JoinEventButton event={makeEvent({ isOnline: false })} />);
+    expect(screen.queryByRole("link", { name: /join online/i })).not.toBeInTheDocument();
+  });
+
+  it("does not render for online events without a meeting url", () => {
+    render(<JoinEventButton event={makeEvent({ meetingUrl: null })} />);
+    expect(screen.queryByRole("link", { name: /join online/i })).not.toBeInTheDocument();
+  });
+
+  it("does not render once the event date has passed", () => {
+    render(<JoinEventButton event={makeEvent({ date: new Date("2020-01-01") })} />);
+    expect(screen.queryByRole("link", { name: /join online/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/JoinEventButton/JoinEventButton.tsx
+++ b/src/components/JoinEventButton/JoinEventButton.tsx
@@ -1,0 +1,25 @@
+import type { Event } from "../../types/types";
+import { isEventExpired } from "../../utils/script";
+
+export default function JoinEventButton({ event }: JoinEventButtonProps) {
+  const { isOnline, meetingUrl } = event;
+
+  if (!isOnline || !meetingUrl || isEventExpired(event)) {
+    return null;
+  }
+
+  return (
+    <a
+      href={meetingUrl}
+      className="cnf-button cnf-button__gold"
+      target="_blank"
+      style={{ display: "inline-block" }}
+    >
+      <span className="cnf-button__text">Join online</span>
+    </a>
+  );
+}
+
+type JoinEventButtonProps = {
+  event: Event;
+};

--- a/src/lib/rsvpTypes.ts
+++ b/src/lib/rsvpTypes.ts
@@ -41,6 +41,14 @@ export const RSVP_LABELS: Record<RsvpStatus, string> = {
   not_going: "Not going",
 };
 
+// Used once an event has passed, so the attendance breakdown reads as a
+// record of what happened rather than a still-open invitation.
+export const PAST_RSVP_LABELS: Record<RsvpStatus, string> = {
+  going: "Went",
+  maybe: "Maybe",
+  not_going: "Didn't go",
+};
+
 export function isRsvpStatus(value: unknown): value is RsvpStatus {
   return typeof value === "string" && (RSVP_STATUSES as readonly string[]).includes(value);
 }

--- a/src/pages/[clubSlug]/events/[eventSlug].astro
+++ b/src/pages/[clubSlug]/events/[eventSlug].astro
@@ -6,6 +6,7 @@ import "../../../styles/event.css";
 import { getCollection } from "astro:content";
 import Banner from "../../../layouts/Banner.astro";
 import EventRsvp from "../../../components/EventRsvp/EventRsvp";
+import JoinEventButton from "../../../components/JoinEventButton/JoinEventButton";
 import { getDisplayName } from "../../../lib/memberDisplay";
 import { getAllClubs, clubSlugsForEvent } from "../../../lib/clubs";
 import { DEFAULT_CLUB_SLUG } from "../../../lib/clubDefaults";
@@ -79,6 +80,7 @@ const canonicalPath = event.data.location
         >Hosted by <a href={`/profile/${event.data.creator.username}`}>{getDisplayName(event.data.creator)}</a></span
       >
     </div>
+    <JoinEventButton event={event.data} />
   </section>
 
   <section class="cnf-section">

--- a/src/utils/script.ts
+++ b/src/utils/script.ts
@@ -16,8 +16,14 @@ export function formatEventDate(date: Date): string {
   ).padStart(2, "0")}`;
 }
 
+// Shared "has this already happened" check, so every consumer compares
+// dates the same way instead of each reimplementing `new Date(x) < new Date()`.
+export function isPastDate(date: Date | string) {
+  return new Date(date) < new Date();
+}
+
 export function isEventExpired(event: Event | null) {
-  return event ? new Date(event.date) < new Date() : true;
+  return event ? isPastDate(event.date) : true;
 }
 
 export function isValidEmail(email: string) {


### PR DESCRIPTION
Closes #31.

### Why

Events already store a `meeting_url`, but theres no visible way for a member to actually join an online event from its page. This PR adds a "Join event" button that links directly to it.

### How it was achieved

- **`src/components/JoinEventButton/JoinEventButton.tsx`** — renders iff the event is online (`isOnline`) **and** a `meeting_url` is set **and** the event date has not passed. When any of those is false, nothing renders.
- **Wired into the event page** (`src/pages/[clubSlug]/events/[eventSlug].astro`) — shown on upcoming events only, not restricted to day-of, and not gated behind membership (consistent with event pages being public-facing).
- **Tests** — `JoinEventButton.test.tsx` covers the three visibility cases (online+URL+upcoming → shown; in-person → hidden; online missing URL → hidden). Diagnostics gate green: `tsc`, `@astrojs/check`, 121 vitest passing, build succeeds.

### Concerns & Comments

- The button appears as soon as `meeting_url` is set, not only on the day of the event — visibility is governed by the event date, matching the rest of the event page.
- No member-only gating, in line with events being public-facing.