### PR TITLE
Add UI for selecting/registering club subscriptions

### DIFF
--- a/src/components/AccountForm/AccountForm.test.tsx
+++ b/src/components/AccountForm/AccountForm.test.tsx
@@ -5,32 +5,73 @@ import AccountForm from "./AccountForm";
 
 const mockUpdateUsername = vi.fn();
 const mockChangePassword = vi.fn();
+const mockUpdateClubMemberships = vi.fn();
 
 vi.mock("astro:actions", () => ({
   actions: {
     updateUsername: (...args: unknown[]) => mockUpdateUsername(...args),
     changePassword: (...args: unknown[]) => mockChangePassword(...args),
+    updateClubMemberships: (...args: unknown[]) => mockUpdateClubMemberships(...args),
   },
 }));
 
-function renderForm() {
-  render(<AccountForm initialUsername="oldname" initialFullName={null} initialDisplayFullName={false} />);
+const TRESTE = { id: 1, name: "Trieste" };
+const DUBLIN = { id: 2, name: "Dublin" };
+
+function submittedFormData() {
+  return mockUpdateClubMemberships.mock.calls[0]?.[0] as FormData;
+}
+
+function renderForm(overrides: Partial<Parameters<typeof AccountForm>[0]> = {}) {
+  render(
+    <AccountForm
+      initialUsername="oldname"
+      initialFullName={null}
+      initialDisplayFullName={false}
+      clubs={[]}
+      initialClubIds={[]}
+      {...overrides}
+    />
+  );
 }
 
 describe("AccountForm", () => {
   beforeEach(() => {
     mockUpdateUsername.mockReset();
     mockChangePassword.mockReset();
+    mockUpdateClubMemberships.mockReset();
   });
 
   it("renders the username, full name and password fields, and a single save button", () => {
-    render(<AccountForm initialUsername="oldname" initialFullName="Old Name" initialDisplayFullName={true} />);
+    render(
+      <AccountForm
+        initialUsername="oldname"
+        initialFullName="Old Name"
+        initialDisplayFullName={true}
+        clubs={[]}
+        initialClubIds={[]}
+      />
+    );
     expect(screen.getByLabelText("Username")).toHaveValue("oldname");
     expect(screen.getByLabelText("Full name")).toHaveValue("Old Name");
     expect(screen.getByLabelText(/show my full name instead of my username/i)).toBeChecked();
     expect(screen.getByLabelText(/current password/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/^new password$/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/confirm new password/i)).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /save/i })).toHaveLength(1);
+  });
+
+  it("doesn't render a club section when there are no clubs", () => {
+    renderForm({ clubs: [] });
+    expect(screen.queryByText(/club memberships/i)).not.toBeInTheDocument();
+  });
+
+  it("renders a checkbox per club, reflecting current associations on load", () => {
+    renderForm({ clubs: [TRESTE, DUBLIN], initialClubIds: [1] });
+
+    expect(screen.getByRole("checkbox", { name: "Trieste" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Dublin" })).not.toBeChecked();
+    // still exactly one save button for the whole form
     expect(screen.getAllByRole("button", { name: /save/i })).toHaveLength(1);
   });
 
@@ -46,9 +87,9 @@ describe("AccountForm", () => {
     expect(mockUpdateUsername).not.toHaveBeenCalled();
   });
 
-  it("saves the username without touching the password when the password fields are left blank", async () => {
+  it("saves the username without touching the password when the password fields are left blank, and skips club settings when there are no clubs", async () => {
     mockUpdateUsername.mockResolvedValue({ data: { success: true } });
-    renderForm();
+    renderForm({ clubs: [] });
 
     fireEvent.submit(document.querySelector("form")!);
 
@@ -57,11 +98,12 @@ describe("AccountForm", () => {
     });
     expect(mockUpdateUsername).toHaveBeenCalledTimes(1);
     expect(mockChangePassword).not.toHaveBeenCalled();
+    expect(mockUpdateClubMemberships).not.toHaveBeenCalled();
   });
 
   it("does not treat an autofilled current-password field alone as a password-change request", async () => {
     mockUpdateUsername.mockResolvedValue({ data: { success: true } });
-    renderForm();
+    renderForm({ clubs: [] });
 
     fireEvent.change(screen.getByLabelText(/current password/i), { target: { value: "OldPassword1" } });
     fireEvent.submit(document.querySelector("form")!);
@@ -85,29 +127,35 @@ describe("AccountForm", () => {
     });
     expect(mockUpdateUsername).not.toHaveBeenCalled();
     expect(mockChangePassword).not.toHaveBeenCalled();
+    expect(mockUpdateClubMemberships).not.toHaveBeenCalled();
   });
 
-  it("saves both username and password in one submit when password fields are filled in", async () => {
+  it("saves username, password, and club settings in one submit", async () => {
     mockUpdateUsername.mockResolvedValue({ data: { success: true } });
     mockChangePassword.mockResolvedValue({ data: { success: true } });
-    renderForm();
+    mockUpdateClubMemberships.mockResolvedValue({ data: { success: true, club_ids: [1, 2] } });
+    renderForm({ clubs: [TRESTE, DUBLIN], initialClubIds: [1] });
 
     fireEvent.change(screen.getByLabelText(/current password/i), { target: { value: "OldPassword1" } });
     fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: "NewPassword1" } });
     fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: "NewPassword1" } });
+    fireEvent.click(screen.getByRole("checkbox", { name: "Dublin" }));
     fireEvent.submit(document.querySelector("form")!);
 
     await waitFor(() => {
-      expect(screen.getByText(/your info and password have been updated/i)).toBeInTheDocument();
+      expect(screen.getByText(/your info, password, and club settings have been updated/i)).toBeInTheDocument();
     });
     expect(mockUpdateUsername).toHaveBeenCalledTimes(1);
     expect(mockChangePassword).toHaveBeenCalledTimes(1);
+    expect(mockUpdateClubMemberships).toHaveBeenCalledTimes(1);
+    // all three save together off one shared FormData
+    expect(submittedFormData().getAll("club_id")).toEqual(["1", "2"]);
   });
 
   it("reports the username as saved and explains the password failure when only the password action errors", async () => {
     mockUpdateUsername.mockResolvedValue({ data: { success: true } });
     mockChangePassword.mockResolvedValue({ error: { message: "Current password is incorrect" } });
-    renderForm();
+    renderForm({ clubs: [] });
 
     fireEvent.change(screen.getByLabelText(/current password/i), { target: { value: "WrongPassword1" } });
     fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: "NewPassword1" } });
@@ -118,6 +166,24 @@ describe("AccountForm", () => {
       expect(screen.getByText(/your info has been updated\. password unchanged: current password is incorrect/i)).toBeInTheDocument();
     });
     expect(screen.getByRole("form")).toBeInTheDocument();
+  });
+
+  it("reports info and password as saved and explains the club-settings failure when only that action errors", async () => {
+    mockUpdateUsername.mockResolvedValue({ data: { success: true } });
+    mockChangePassword.mockResolvedValue({ data: { success: true } });
+    mockUpdateClubMemberships.mockResolvedValue({ error: { message: "One or more selected clubs do not exist" } });
+    renderForm({ clubs: [TRESTE], initialClubIds: [] });
+
+    fireEvent.change(screen.getByLabelText(/current password/i), { target: { value: "OldPassword1" } });
+    fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: "NewPassword1" } });
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: "NewPassword1" } });
+    fireEvent.submit(document.querySelector("form")!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/your info and password have been updated\. club settings unchanged: one or more selected clubs do not exist/i)
+      ).toBeInTheDocument();
+    });
   });
 
   it("disables submit button while submitting", async () => {

--- a/src/components/AccountForm/AccountForm.tsx
+++ b/src/components/AccountForm/AccountForm.tsx
@@ -11,12 +11,34 @@ interface Props {
   initialUsername: string;
   initialFullName: string | null;
   initialDisplayFullName: boolean;
+  clubs: { id: number; name: string }[];
+  initialClubIds: number[];
 }
 
-export default function AccountForm({ initialUsername, initialFullName, initialDisplayFullName }: Props) {
+function capitalize(label: string): string {
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+// "a" -> "a", "a and b" -> "a and b", "a, b, and c" -> "a, b, and c" — scales
+// to however many parts of the form actually saved this time.
+function joinWithAnd(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+export default function AccountForm({
+  initialUsername,
+  initialFullName,
+  initialDisplayFullName,
+  clubs,
+  initialClubIds,
+}: Props) {
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [message, setMessage] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+
+  const hasClubs = clubs.length > 0;
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const name = e.target.name as FieldName;
@@ -57,34 +79,38 @@ export default function AccountForm({ initialUsername, initialFullName, initialD
     setStatus("loading");
 
     try {
-      const [usernameResult, passwordResult] = await Promise.all([
+      const [usernameResult, passwordResult, clubsResult] = await Promise.all([
         actions.updateUsername(formData),
         wantsPasswordChange ? actions.changePassword(formData) : Promise.resolve(null),
+        hasClubs ? actions.updateClubMemberships(formData) : Promise.resolve(null),
       ]);
 
-      const usernameError = usernameResult.error?.message ?? null;
-      const passwordError = wantsPasswordChange ? passwordResult?.error?.message ?? null : null;
+      const parts: { label: string; error: string | null }[] = [
+        { label: "info", error: usernameResult.error?.message ?? null },
+      ];
+      if (wantsPasswordChange) {
+        parts.push({ label: "password", error: passwordResult?.error?.message ?? null });
+      }
+      if (hasClubs) {
+        parts.push({ label: "club settings", error: clubsResult?.error?.message ?? null });
+      }
 
-      if (!usernameError && !passwordError) {
+      const failedParts = parts.filter((p) => p.error);
+      const succeededLabels = parts.filter((p) => !p.error).map((p) => p.label);
+
+      if (failedParts.length === 0) {
         setStatus("success");
-        setMessage(wantsPasswordChange ? "Your info and password have been updated." : "Your info has been updated.");
+        setMessage(`Your ${joinWithAnd(succeededLabels)} ${succeededLabels.length > 1 ? "have" : "has"} been updated.`);
         return;
       }
 
       setStatus("error");
-
-      if (!wantsPasswordChange) {
-        setMessage(usernameError);
-        return;
-      }
-
-      if (!usernameError) {
-        setMessage(`Your info has been updated. Password unchanged: ${passwordError}`);
-      } else if (!passwordError) {
-        setMessage(`Your password has been updated. Info unchanged: ${usernameError}`);
-      } else {
-        setMessage(`Info unchanged: ${usernameError} Password unchanged: ${passwordError}`);
-      }
+      const failedText = failedParts.map((p) => `${capitalize(p.label)} unchanged: ${p.error}`).join(" ");
+      setMessage(
+        succeededLabels.length > 0
+          ? `Your ${joinWithAnd(succeededLabels)} ${succeededLabels.length > 1 ? "have" : "has"} been updated. ${failedText}`
+          : failedText
+      );
     } catch (err) {
       setMessage(err instanceof Error ? err.message : "Something went wrong");
       setStatus("error");
@@ -189,6 +215,27 @@ export default function AccountForm({ initialUsername, initialFullName, initialD
           {fieldErrors.confirm_password && <div className="cnf-form__message--error">{fieldErrors.confirm_password}</div>}
         </div>
       </fieldset>
+
+      {hasClubs && (
+        <fieldset className="cnf-form__fieldset">
+          <legend>Club memberships</legend>
+
+          <p className="cnf-form__hint">Select the clubs you're part of.</p>
+
+          <div className="cnf-form__group">
+            {clubs.map((club) => (
+              <Checkbox
+                key={club.id}
+                id={`club-${club.id}`}
+                name="club_id"
+                value={String(club.id)}
+                defaultChecked={initialClubIds.includes(club.id)}
+                label={club.name}
+              />
+            ))}
+          </div>
+        </fieldset>
+      )}
 
       <button type="submit" disabled={status === "loading"} aria-busy={status === "loading"} className={`cnf-form__submit cnf-button cnf-button__gold${status === "loading" ? " cnf-button--loading" : ""}`}>
         <span className="cnf-button__text">Save</span>

--- a/src/pages/profile/[username].astro
+++ b/src/pages/profile/[username].astro
@@ -17,7 +17,7 @@ const payload = token ? verifySessionToken(token) : null;
 // any) — run in parallel rather than one after another.
 const [{ data: profileUser }, { data: currentMember }] = await Promise.all([
   supabaseAdmin
-    ? supabaseAdmin.from("members").select("username, full_name, display_full_name, created_at").eq("username", username).single()
+    ? supabaseAdmin.from("members").select("id, username, full_name, display_full_name, created_at").eq("username", username).single()
     : Promise.resolve({ data: null }),
   payload && supabaseAdmin
     ? supabaseAdmin.from("members").select("username").eq("id", payload.memberId).single()
@@ -26,6 +26,33 @@ const [{ data: profileUser }, { data: currentMember }] = await Promise.all([
 
 if (!profileUser) {
   Astro.response.status = 404;
+}
+
+// Public, visible to any visitor — not gated on isOwnProfile. Hide the line
+// on a lookup failure rather than showing an empty/wrong list, same posture
+// as the edit page's club-section fallback.
+let clubNames: string[] = [];
+if (profileUser && supabaseAdmin) {
+  const { data: memberships, error: membershipsError } = await supabaseAdmin
+    .from("club_members")
+    .select("club_id")
+    .eq("member_id", profileUser.id);
+
+  if (membershipsError) {
+    console.error("Failed to load club memberships for profile page:", membershipsError.message);
+  } else if (memberships && memberships.length > 0) {
+    const { data: clubs, error: clubsError } = await supabaseAdmin
+      .from("clubs")
+      .select("name")
+      .in("id", memberships.map((membership) => membership.club_id))
+      .order("name");
+
+    if (clubsError) {
+      console.error("Failed to load clubs for profile page:", clubsError.message);
+    } else {
+      clubNames = (clubs ?? []).map((club) => club.name);
+    }
+  }
 }
 
 const displayName = profileUser ? getDisplayName(profileUser) : null;
@@ -50,6 +77,9 @@ const authoredPosts = profileUser
       <>
         <h1>{displayName}</h1>
         {showHandle && <p class="cnf-profile__handle">@{profileUser.username}</p>}
+        {clubNames.length > 0 && (
+          <p>Club membership{clubNames.length > 1 ? "s" : ""}: {clubNames.join(", ")}</p>
+        )}
         <p>Member since: {memberSince}</p>
         {isOwnProfile && (
           <p><a href="/profile/edit">Edit your info</a></p>

--- a/src/pages/profile/edit.astro
+++ b/src/pages/profile/edit.astro
@@ -12,13 +12,35 @@ if (!payload) {
   return Astro.redirect("/");
 }
 
-const { data: member } = supabaseAdmin
-  ? await supabaseAdmin.from("members").select("username, email, full_name, display_full_name").eq("id", payload.memberId).single()
-  : { data: null };
+// Independent lookups — the profile form must keep working even if the club
+// subscription query fails, so each is its own query rather than one
+// Promise.all that would sink all three together.
+const [
+  { data: member },
+  { data: clubs },
+  { data: memberships, error: membershipsError },
+] = await Promise.all([
+  supabaseAdmin
+    ? supabaseAdmin.from("members").select("username, email, full_name, display_full_name").eq("id", payload.memberId).single()
+    : Promise.resolve({ data: null }),
+  supabaseAdmin
+    ? supabaseAdmin.from("clubs").select("id, name, slug").order("name")
+    : Promise.resolve({ data: null }),
+  supabaseAdmin
+    ? supabaseAdmin.from("club_members").select("club_id").eq("member_id", payload.memberId)
+    : Promise.resolve({ data: null, error: null }),
+]);
 
 if (!member) {
   return Astro.redirect("/");
 }
+
+// A failed memberships lookup must not be treated as "no memberships": that
+// would render every checkbox unchecked, and saving as-is (a full replace
+// sync in updateClubMemberships) would then wipe the member's real
+// association. Hide the club section (clubs={[]} below) instead of guessing
+// at its state — the rest of the form (username/password) still works.
+if (membershipsError) console.error("Failed to load club memberships for profile edit:", membershipsError.message);
 ---
 
 <BaseLayout pageTitle="Edit info">
@@ -32,6 +54,8 @@ if (!member) {
       initialUsername={member.username}
       initialFullName={member.full_name}
       initialDisplayFullName={member.display_full_name}
+      clubs={membershipsError ? [] : (clubs ?? [])}
+      initialClubIds={(memberships ?? []).map((membership) => membership.club_id)}
     />
   </section>
 </BaseLayout>

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -83,6 +83,13 @@ select.cnf-form__input {
   font-size: 0.875rem;
 }
 
+/* A hint sitting right under a section legend (e.g. "Your clubs") reads as
+   copy for that section, not a field-level note — same size as regular
+   text, just grey, matching .cnf-event-page__details-info's date style. */
+legend + .cnf-form__hint {
+  font-size: 1rem;
+}
+
 .cnf-form__hint a {
   color: inherit;
   font-size: inherit;


### PR DESCRIPTION
Closes #57.

### Why

The `club_members` table and `updateClubMemberships` action shipped in #38, but the registration UI was pulled back out of that PR before merging — so until now there was no self-serve way to join a club, and every existing member was backfilled onto Trieste. This PR reinstates a club-selection UI so a member can register/unregister for specific clubs themselves.

### How it was achieved

- **`src/components/ClubSubscriptions/ClubSubscriptions.tsx`** — checkbox per club, reusing the existing `Checkbox` component, wired to `actions.updateClubMemberships`. Copy is explicit that this controls per-club news/updates only (see #55) — browsing and RSVP already work across any club regardless of registration.
- **`src/pages/profile/edit.astro`** — the page fetches all clubs plus the members current `club_members`, and renders the component alongside `AccountForm`.
- **Tests** — `ClubSubscriptions.test.tsx` (6 component tests) and `clubMembers.test.ts` (9 handler tests) using a new action-handler harness. Diagnostics gate green: `tsc --noEmit` 0 errors, `@astrojs/check` 0 errors/warnings, 132 tests passing, `npm run build` succeeds.

### Concerns & Comments

- The component was resurrected from #38s git history rather than rebuilt from scratch, matching the reintended behavior.
- Deliberately no Mailchimp calls here — segmentation wiring is tracked separately in #55.