### PR TITLE
fix: center modal in viewport instead of document flow

### DIFF
--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -3,7 +3,9 @@ body.cnf-modal-open {
 }
 
 .cnf-modal {
-  position: relative;
+  position: fixed;
+  inset: 0;
+  margin: auto;
   border: none;
   border-radius: var(--border-radius);
   padding: 1.5rem;


### PR DESCRIPTION
Fixes a bug where opening a modal (e.g. clicking an RSVP status button, or Login) after scrolling the page shows the dialog off-screen at the top instead of centered in the current viewport.

Root cause: the native `<dialog>` UA stylesheet centers a shown modal via `position: fixed` + `inset: 0` + `margin: auto`. `.cnf-modal` overrode `position` to `relative` with no insets, which dropped it out of that fixed/viewport-centered behavior.

Fix: `position: fixed; inset: 0; margin: auto;` — the standard native-dialog centering technique. Doesn't conflict with the existing open/close `transform: scale(...)` animation since that doesn't use transform for positioning.

Verified live: scrolled the event page down, opened the modal, confirmed it renders centered in the current viewport rather than at the top of the document.