### PR TITLE
Serve Apple Calendar link as a real .ics file, not a data: URI

### DIFF
--- a/src/lib/clubs.test.ts
+++ b/src/lib/clubs.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Local, per-test control over both Supabase and the content collection —
+// mutable `state`/`mockEvents` the mock factories read at call time, while
+// `vi.resetModules()` + a fresh dynamic import gives each test its own
+// getAllClubs() cache (see clubs.ts) instead of leaking across tests.
+const state: {
+  clubsList: { id: number; name: string; slug: string }[] | null;
+  clubsError: { message: string } | null;
+  fromCalls: number;
+} = { clubsList: null, clubsError: null, fromCalls: 0 };
+
+let mockEvents: unknown[] = [];
+
+vi.mock("./supabase", () => ({
+  supabase: null,
+  supabaseAdmin: {
+    from: (table: string) => {
+      if (table !== "clubs") throw new Error(`Unexpected table: ${table}`);
+      state.fromCalls += 1;
+      return { select: () => Promise.resolve({ data: state.clubsList, error: state.clubsError }) };
+    },
+  },
+}));
+
+vi.mock("astro:content", () => ({
+  getCollection: () => Promise.resolve(mockEvents),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  state.clubsList = null;
+  state.clubsError = null;
+  state.fromCalls = 0;
+  mockEvents = [];
+});
+
+async function importClubs() {
+  return import("./clubs");
+}
+
+describe("getAllClubs", () => {
+  it("throws when the clubs table comes back empty, refusing to silently build zero pages", async () => {
+    state.clubsList = [];
+    const { getAllClubs } = await importClubs();
+
+    await expect(getAllClubs()).rejects.toThrow(/zero clubs/);
+  });
+
+  it("clears its cache on failure so a later retry can succeed", async () => {
+    state.clubsList = [];
+    const { getAllClubs } = await importClubs();
+    await expect(getAllClubs()).rejects.toThrow();
+
+    state.clubsList = [{ id: 1, name: "Trieste", slug: "trieste" }];
+    await expect(getAllClubs()).resolves.toEqual(state.clubsList);
+  });
+
+  it("memoizes a successful result — a second call doesn't hit Supabase again", async () => {
+    state.clubsList = [{ id: 1, name: "Trieste", slug: "trieste" }];
+    const { getAllClubs } = await importClubs();
+
+    const first = await getAllClubs();
+    state.clubsList = [{ id: 2, name: "Oslo", slug: "oslo" }]; // would change the answer if re-fetched
+    const second = await getAllClubs();
+
+    expect(second).toEqual(first);
+    expect(second).toEqual([{ id: 1, name: "Trieste", slug: "trieste" }]);
+    expect(state.fromCalls).toBe(1);
+  });
+});
+
+describe("getEventClubStaticPaths", () => {
+  it("gives a club-scoped event exactly one path, under its own club", async () => {
+    state.clubsList = [
+      { id: 1, name: "Trieste", slug: "trieste" },
+      { id: 2, name: "Oslo", slug: "oslo" },
+    ];
+    mockEvents = [
+      { data: { slug: "philosophy-night", location: { id: 1, name: "Trieste", slug: "trieste" } } },
+    ];
+    const { getEventClubStaticPaths } = await importClubs();
+
+    const paths = await getEventClubStaticPaths();
+
+    expect(paths).toEqual([
+      { params: { clubSlug: "trieste", eventSlug: "philosophy-night" }, props: { event: mockEvents[0] } },
+    ]);
+  });
+
+  it("fans a cross-chapter event (location: null) out across every existing club", async () => {
+    state.clubsList = [
+      { id: 1, name: "Trieste", slug: "trieste" },
+      { id: 2, name: "Oslo", slug: "oslo" },
+    ];
+    mockEvents = [{ data: { slug: "global-meetup", location: null } }];
+    const { getEventClubStaticPaths } = await importClubs();
+
+    const paths = await getEventClubStaticPaths();
+
+    expect(paths.map((p) => p.params.clubSlug).sort()).toEqual(["oslo", "trieste"]);
+    paths.forEach((p) => expect(p.params.eventSlug).toBe("global-meetup"));
+  });
+});

--- a/src/lib/clubs.ts
+++ b/src/lib/clubs.ts
@@ -1,4 +1,6 @@
+import { getCollection } from 'astro:content';
 import { supabaseAdmin } from './supabase';
+import type { EventCollection } from '../types/types';
 
 export type Club = { id: number; name: string; slug: string };
 
@@ -11,7 +13,19 @@ export { DEFAULT_CLUB_SLUG } from './clubDefaults';
 // loader (to resolve an event's club) and by the [clubSlug] static routes
 // (#39) to know which club-prefixed pages to build, including a club with
 // zero events yet.
-export async function getAllClubs(): Promise<Club[]> {
+//
+// Memoized per build/process: [eventSlug].astro and [eventSlug].ics.ts each
+// run their own getStaticPaths (Astro doesn't share state between route
+// files), and without this cache both independently hit Supabase for the
+// exact same "every club" data. Caching also closes a real divergence risk —
+// two live, unmemoized queries a moment apart could see a different club
+// list if the clubs table changed mid-build, desyncing which .ics files
+// exist from which event pages link to them. A rejected fetch clears the
+// cache so a real Supabase outage doesn't wedge every future call in the
+// same process into a stale failure.
+let clubsPromise: Promise<Club[]> | null = null;
+
+async function fetchAllClubs(): Promise<Club[]> {
   if (!supabaseAdmin) {
     throw new Error('Supabase is not configured — set SUPABASE_PROJECT_URL and SUPABASE_SECRET_KEY');
   }
@@ -28,6 +42,16 @@ export async function getAllClubs(): Promise<Club[]> {
   return data;
 }
 
+export async function getAllClubs(): Promise<Club[]> {
+  if (!clubsPromise) {
+    clubsPromise = fetchAllClubs().catch((error) => {
+      clubsPromise = null;
+      throw error;
+    });
+  }
+  return clubsPromise;
+}
+
 // #39: the set of club slugs a given event belongs under — the club it's
 // actually scoped to, or, for a genuinely cross-chapter event (location
 // null), every club that exists (the "visible everywhere" decision). Shared
@@ -35,4 +59,25 @@ export async function getAllClubs(): Promise<Club[]> {
 // the list page and the detail page's getStaticPaths.
 export function clubSlugsForEvent(location: { slug: string } | null, allClubSlugs: string[]): string[] {
   return location ? [location.slug] : allClubSlugs;
+}
+
+export type EventClubPath = {
+  params: { clubSlug: string; eventSlug: string };
+  props: { event: EventCollection };
+};
+
+// The getStaticPaths shared by [eventSlug].astro and [eventSlug].ics.ts —
+// every event/club pair that needs a page, kept in exactly one place instead
+// of copy-pasted so the two routes can't drift out of lockstep with each
+// other.
+export async function getEventClubStaticPaths(): Promise<EventClubPath[]> {
+  const [events, clubs] = await Promise.all([getCollection('event'), getAllClubs()]);
+  const clubSlugs = clubs.map((c) => c.slug);
+
+  return events.flatMap((event) =>
+    clubSlugsForEvent(event.data.location, clubSlugs).map((clubSlug) => ({
+      params: { clubSlug, eventSlug: event.data.slug },
+      props: { event },
+    }))
+  );
 }

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -5,6 +5,8 @@
 // in Trieste or remote. DTEND is DTSTART + DEFAULT_EVENT_DURATION_MS because
 // there's no stored end time yet; revisit if a duration field is ever added.
 
+import type { EventCollection } from "../types/types";
+
 const DEFAULT_EVENT_DURATION_MS = 90 * 60 * 1000; // 1.5 hours — e.g. an 18:30 start ends at 20:00
 const MAX_LINE_OCTETS = 75;
 
@@ -18,6 +20,15 @@ export type EventIcsData = {
   description: string | null;
   summary: string | null;
 };
+
+// The one place that narrows a full event collection entry down to what the
+// calendar builders below need — used by both [eventSlug].astro (Google
+// Calendar link) and [eventSlug].ics.ts (the served .ics file) so the two
+// outputs can't quietly disagree on content if EventIcsData's fields change.
+export function toEventIcsData(event: EventCollection): EventIcsData {
+  const { name, date, isOnline, venue, meetingUrl, slug, description, summary } = event.data;
+  return { name, date, isOnline, venue, meetingUrl, slug, description, summary };
+}
 
 function pad(n: number): string {
   return String(n).padStart(2, "0");

--- a/src/pages/[clubSlug]/events/[eventSlug].astro
+++ b/src/pages/[clubSlug]/events/[eventSlug].astro
@@ -2,34 +2,25 @@
 export const prerender = true;
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import { formatEventDate, isEventExpired } from "../../../utils/script";
-import { buildEventIcs, buildGoogleCalendarUrl } from "../../../lib/ics";
+import { buildGoogleCalendarUrl, toEventIcsData } from "../../../lib/ics";
 import "../../../styles/event.css";
-import { getCollection } from "astro:content";
 import Banner from "../../../layouts/Banner.astro";
 import EventRsvp from "../../../components/EventRsvp/EventRsvp";
 import JoinEventButton from "../../../components/JoinEventButton/JoinEventButton";
 import AddToCalendarButton from "../../../components/AddToCalendarButton/AddToCalendarButton";
 import { getDisplayName } from "../../../lib/memberDisplay";
-import { getAllClubs, clubSlugsForEvent } from "../../../lib/clubs";
+import { getEventClubStaticPaths } from "../../../lib/clubs";
 import { DEFAULT_CLUB_SLUG } from "../../../lib/clubDefaults";
 
-export async function getStaticPaths() {
-  const [events, clubs] = await Promise.all([getCollection("event"), getAllClubs()]);
-  const clubSlugs = clubs.map((c) => c.slug);
-
-  // #39: an event with a club gets exactly one URL, under that club's
-  // prefix. A genuinely cross-chapter event (location null) has no club of
-  // its own, so — matching the "visible everywhere" call on the list page —
-  // it gets one URL per existing club instead of a single fixed one.
-  return events.flatMap((event) =>
-    clubSlugsForEvent(event.data.location, clubSlugs).map((clubSlug) => ({
-      params: { clubSlug, eventSlug: event.data.slug },
-      props: { event },
-    }))
-  );
-}
+// #39: an event with a club gets exactly one URL, under that club's prefix. A
+// genuinely cross-chapter event (location null) has no club of its own, so —
+// matching the "visible everywhere" call on the list page — it gets one URL
+// per existing club instead of a single fixed one. Shared with
+// [eventSlug].ics.ts so the two routes can't drift out of lockstep.
+export const getStaticPaths = getEventClubStaticPaths;
 
 const { event } = Astro.props;
+const { clubSlug } = Astro.params;
 // A cross-chapter event is duplicated across every club's URL space — give
 // them all ONE shared canonical (the default club's copy) instead of each
 // page self-referencing, which would otherwise be duplicate-content SEO-wise
@@ -38,30 +29,21 @@ const canonicalPath = event.data.location
   ? undefined
   : `/${DEFAULT_CLUB_SLUG}/events/${event.data.slug}/`;
 
-// #28: an "Add to calendar" dropdown for upcoming events (Google Calendar /
-// Apple Calendar), built at build time from the same normalized event data
+// #28/#76: an "Add to calendar" dropdown for upcoming events (Google Calendar
+// / Apple Calendar), built at build time from the same normalized event data
 // the page renders. Google gets a real deep link — no file, no MIME
-// sniffing. Apple/Outlook-desktop/everything-else gets the .ics as a data:
-// URI with a `download` filename — confirmed live (2026-09-04) that
-// dropping `download` makes Chrome save it as a generic "download.ics"
-// instead. AddToCalendarButton itself handles the Safari exception
-// client-side (drops `download` only for real Safari, once detected, so its
-// native text/calendar handoff can take over) rather than this static href
-// trying to serve every browser at once. Past events get no button.
+// sniffing. Apple/Outlook-desktop/everything-else gets a real same-origin
+// .ics file at [eventSlug].ics.ts (kept as a separate static route in
+// lockstep with this page's own getStaticPaths) rather than a `data:` URI —
+// WebKit blocks top-level navigation to `data:` URLs, which silently broke
+// "Apple Calendar" in real iOS Safari (#76). AddToCalendarButton still keeps
+// a `download` filename for every browser except real Safari (confirmed live
+// 2026-09-04: without it, Chrome saves a generic "download.ics") — that part
+// is unaffected by the swap since it works the same on a real URL. Past
+// events get no button.
 const isCalendarVisible = !isEventExpired(event.data);
-const icsEventData = {
-  name: event.data.name,
-  date: event.data.date,
-  isOnline: event.data.isOnline,
-  venue: event.data.venue,
-  meetingUrl: event.data.meetingUrl,
-  slug: event.data.slug,
-  description: event.data.description,
-  summary: event.data.summary,
-};
-const icsHref = `data:text/calendar;charset=utf-8,${encodeURIComponent(
-  buildEventIcs(icsEventData)
-)}`;
+const icsEventData = toEventIcsData(event);
+const icsHref = `/${clubSlug}/events/${event.data.slug}.ics`;
 const icsFilename = `${event.data.slug}.ics`;
 const googleCalendarUrl = buildGoogleCalendarUrl(icsEventData);
 ---

--- a/src/pages/[clubSlug]/events/[eventSlug].ics.ts
+++ b/src/pages/[clubSlug]/events/[eventSlug].ics.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from "astro";
+import { buildEventIcs, toEventIcsData } from "../../../lib/ics";
+import { getEventClubStaticPaths } from "../../../lib/clubs";
+import type { EventCollection } from "../../../types/types";
+
+// Same club/event pairing as [eventSlug].astro's own getStaticPaths — a
+// shared helper (src/lib/clubs.ts) instead of a copy-pasted one, so every
+// event page that exists is guaranteed to have a matching .ics file at the
+// same clubSlug/eventSlug pair.
+export const getStaticPaths = getEventClubStaticPaths;
+
+// A real same-origin .ics file, not a `data:` URI — WebKit blocks top-level
+// navigation to `data:` URLs (an anti-phishing restriction), which is why
+// tapping "Apple Calendar" in real iOS Safari did nothing at all (#76). No
+// Content-Disposition here: leaving it unset lets AddToCalendarButton's own
+// `download` attribute (present for every browser except real Safari) decide
+// save-vs-native-handoff per browser, same as before.
+export const GET: APIRoute<{ event: EventCollection }> = ({ props }) => {
+  const ics = buildEventIcs(toEventIcsData(props.event));
+
+  return new Response(ics, {
+    headers: { "Content-Type": "text/calendar; charset=utf-8" },
+  });
+};

--- a/src/pages/[clubSlug]/events/_[eventSlug].ics.test.ts
+++ b/src/pages/[clubSlug]/events/_[eventSlug].ics.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { GET } from "./[eventSlug].ics";
+import { buildEventIcs, toEventIcsData } from "../../../lib/ics";
+import type { EventCollection } from "../../../types/types";
+
+// A fake collection entry — only the fields toEventIcsData/buildEventIcs
+// actually read, cast to EventCollection since the real schema also carries
+// unrelated fields (location, social, rsvpCounts, ...) this route never uses.
+const event = {
+  data: {
+    name: "Test Talk",
+    date: new Date("2026-09-06T08:18:00Z"),
+    isOnline: false,
+    venue: { name: "Test Venue", url: null },
+    meetingUrl: null,
+    slug: "test-talk",
+    description: null,
+    summary: null,
+  },
+} as unknown as EventCollection;
+
+describe("GET /:clubSlug/events/:eventSlug.ics", () => {
+  it("serves the event's ICS content with the calendar content-type", async () => {
+    const response = await GET({ props: { event } } as Parameters<typeof GET>[0]);
+    const body = await response.text();
+
+    expect(response.headers.get("Content-Type")).toBe("text/calendar; charset=utf-8");
+    // Locks in the route's wiring (props.event -> toEventIcsData -> buildEventIcs)
+    // rather than re-testing buildEventIcs itself, which has its own coverage
+    // in src/lib/ics.test.ts.
+    expect(body).toBe(buildEventIcs(toEventIcsData(event)));
+    expect(body).toContain("SUMMARY:Test Talk");
+  });
+});


### PR DESCRIPTION
Tapping "Apple Calendar" in real iOS Safari closed the dropdown and did nothing — WebKit blocks top-level navigation to `data:` URLs (an anti-phishing restriction), which is exactly how the `.ics` href was built.

Replaced it with a real same-origin `.ics` file served from a new static route (`[eventSlug].ics.ts`), built in lockstep with the event page's own `getStaticPaths`. `AddToCalendarButton`'s existing Safari-vs-everyone-else `download`-attribute logic is untouched, just pointed at a real URL instead of a `data:` blob.

Confirmed working on a real iPhone in Safari.

Closes #76