### PR TITLE
fix: render admin events list date in club timezone, close #75

### DIFF
--- a/src/components/EventList/EventList.tsx
+++ b/src/components/EventList/EventList.tsx
@@ -5,6 +5,7 @@ import EventCard from "../../layouts/EventCard";
 import { formatBlogDate } from "../../utils/script";
 import Selector from "../Selector/Selector";
 import type { EventCollection } from "../../types/types";
+import { DEFAULT_CLUB_TIMEZONE } from "../../lib/clubDefaults";
 
 export default function EventList(props: EventListProps) {
   const cityNames = [...new Set(
@@ -84,7 +85,7 @@ export default function EventList(props: EventListProps) {
         <EventCard
           event={event.data}
           key={event.data.slug}
-          dateFormatter={formatBlogDate}
+          dateFormatter={(date) => formatBlogDate(date, DEFAULT_CLUB_TIMEZONE)}
           clubSlug={props.clubSlug}
         />
     );

--- a/src/pages/admin/events.astro
+++ b/src/pages/admin/events.astro
@@ -5,6 +5,7 @@ import { supabaseAdmin } from "../../lib/supabase";
 import { requireAdmin, scopeToAdminClubs } from "../../lib/auth";
 import { unwrapRelation } from "../../lib/supabaseRelations";
 import { formatBlogDate } from "../../utils/script";
+import { DEFAULT_CLUB_TIMEZONE } from "../../lib/clubDefaults";
 
 // #37: scoped to the caller's clubs, so this can no longer read from the
 // events content collection (its loader drops club_id) - queries Supabase
@@ -50,7 +51,7 @@ const sorted = (data ?? []).map((event) => ({
         {sorted.map((event) => (
           <tr>
             <td data-label="Name">{event.name}</td>
-            <td data-label="Date">{formatBlogDate(event.date)}</td>
+            <td data-label="Date">{formatBlogDate(event.date, DEFAULT_CLUB_TIMEZONE)}</td>
             <td data-label="Location">{event.is_online ? "Online" : event.venue?.name ?? "—"}</td>
             <td><a href={`/admin/events/${event.slug}/edit`}>Edit</a></td>
           </tr>

--- a/src/utils/script.test.ts
+++ b/src/utils/script.test.ts
@@ -59,6 +59,13 @@ describe("formatBlogDate", () => {
     const result = formatBlogDate(new Date("2025-09-04"));
     expect(result).toBe("Sep 4, 2025");
   });
+
+  it("renders the given timeZone's calendar day, not the runtime's own", () => {
+    // 22:30 UTC on Sep 4 is 00:30 in Rome (CEST, UTC+2) the *next* day —
+    // the #75 bug case: no timeZone would show Sep 4, not Sep 5.
+    const result = formatBlogDate(new Date("2026-09-04T22:30:00.000Z"), "Europe/Rome");
+    expect(result).toBe("Sep 5, 2026");
+  });
 });
 
 describe("formatEventDate", () => {

--- a/src/utils/script.ts
+++ b/src/utils/script.ts
@@ -1,10 +1,27 @@
 import type { Event } from "../types/types";
 import { DEFAULT_CLUB_TIMEZONE } from "../lib/clubDefaults";
 
-export function formatBlogDate(date: Date): string {
-  return `${date.toLocaleDateString("en-US", {
-    month: "short",
-  })} ${date.getDate()}, ${date.getFullYear()}`;
+// `timeZone` is optional so blog posts (the one remaining caller that
+// doesn't pass one) are unaffected — pass it explicitly for a date that must
+// read as a specific timezone's calendar day regardless of where the code
+// runs. Both event callers (the admin events list, and the public
+// past-events list in EventList.tsx) now pass DEFAULT_CLUB_TIMEZONE (#75:
+// rendering with no timeZone defaults to wherever the code executes — the
+// server's UTC runtime for the admin page, the visitor's own browser for the
+// client-hydrated public list — either of which can disagree with the
+// club's actual local calendar day for a late-enough event).
+export function formatBlogDate(date: Date, timeZone?: string): string {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    })
+      .formatToParts(date)
+      .map((p) => [p.type, p.value])
+  );
+  return `${parts.month} ${parts.day}, ${parts.year}`;
 }
 
 // Always shown in the club's own local time (see DEFAULT_CLUB_TIMEZONE), not


### PR DESCRIPTION
## What
`admin/events.astro` rendered each event's date with `formatBlogDate`, which had no `timeZone` and defaulted to the server's own runtime timezone (effectively UTC on Netlify). Since #66's timezone fix, event dates are stored as true UTC instants, so a late-evening event whose Rome-local time falls on a different calendar day than its UTC instant would show under the wrong day in the admin list.

While reviewing, found the public site's past-events list (`EventList.tsx` → `EventCard`'s `dateFormatter`) had the same gap, just client-side — no explicit `timeZone`, defaulting to the visitor's own browser timezone instead of Rome. Fixed both in this PR.

## Fix
Gave `formatBlogDate` an optional `timeZone` parameter (defaults to `undefined`, i.e. unchanged behavior for its one remaining caller — blog posts, where this doesn't matter). Passed `DEFAULT_CLUB_TIMEZONE` explicitly from:
- `admin/events.astro` (the original #75 report)
- `EventList.tsx`'s past-events `dateFormatter`

## Verification
- New test: a 22:30 UTC event (00:30 Rome-local, next day) now correctly renders as the next day.
- Full suite: 227/227 passing.
- `tsc --noEmit`: clean.
- `astro check`: 0 errors (1 pre-existing, unrelated hint).

Closes #75.